### PR TITLE
Pretty-print formulas

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -4,7 +4,7 @@ You can edit this file as you like.
 -}
 { name = "my-project"
 , dependencies =
-  [ "console", "effect", "parsing", "psci-support", "spec", "spec-discovery" ]
+  [ "console", "effect", "parsing", "psci-support", "spec", "spec-discovery", "spec-quickcheck" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/src/Parser.purs
+++ b/src/Parser.purs
@@ -10,7 +10,7 @@ import Data.Either (Either)
 import Data.Identity (Identity)
 
 import Text.Parsing.Parser (Parser, ParserT, ParseError, runParser)
-import Text.Parsing.Parser.Combinators (option, chainl1, lookAhead, (<?>))
+import Text.Parsing.Parser.Combinators (option, choice, chainl1, lookAhead, (<?>))
 import Text.Parsing.Parser.String (oneOf, satisfy, eof)
 import Text.Parsing.Parser.Token (GenLanguageDef(..), TokenParser, makeTokenParser, upper, letter)
 import Text.Parsing.Parser.Expr (OperatorTable, Assoc(..), Operator(..), buildExprParser)
@@ -82,12 +82,12 @@ formula = fix allFormulas
 
     opTable :: OperatorTable Identity String Formula
     opTable =
-      [ [ Prefix $ chained (token.reservedOp "¬" $> Not)
-        , Prefix forallParser
-        , Prefix existsParser ]
-      , [ Infix (token.reservedOp "∧" $> And) AssocLeft
-        , Infix (token.reservedOp "∨" $> Or) AssocLeft
-        , Infix (token.reservedOp "→" $> Implies) AssocRight ] ]
+      [ [ Prefix $ chained $ choice [ token.reservedOp "¬" $> Not
+                                    , forallParser
+                                    , existsParser ] ]
+      , [ Infix (token.reservedOp "∧" $> And) AssocLeft ]
+      , [ Infix (token.reservedOp "∨" $> Or) AssocLeft ]
+      , [ Infix (token.reservedOp "→" $> Implies) AssocRight ] ]
 
     allFormulas p = let
       singleFormula = token.parens p <|> predicate

--- a/test/Formula.purs
+++ b/test/Formula.purs
@@ -86,6 +86,7 @@ spec = describe "Formulas" do
   substitutionTests
   disagreementSetTests
   unificationTests
+  showTests
   where
     substitutionTests = describe "substitutions" do
       it "can do substitution on formula" do
@@ -138,3 +139,19 @@ spec = describe "Formulas" do
               , List.fromFoldable [Var (Variable "y"), Var (Variable "y")]
               ])
           `shouldEqual` Nothing
+
+    showTests = describe "show" do
+      it "should handle precedence" do
+        show (Or (Predicate "A" []) (Not $ Predicate "A" []))
+          `shouldEqual` "A ∨ ¬A"
+        show (Exists (Variable "x") (Implies (Predicate "P" [Var $ Variable "x"]) (Predicate "Q" [Var $ Variable "x"])))
+          `shouldEqual` "∃x (P(x) → Q(x))"
+      it "should handle associativity" do
+        show (And (And (Predicate "A" []) (Predicate "B" [])) (Predicate "C" []))
+          `shouldEqual` "A ∧ B ∧ C"
+        show (And (Predicate "A" []) (And (Predicate "B" []) (Predicate "C" [])))
+          `shouldEqual` "A ∧ (B ∧ C)"
+
+      it "should survive show/parseFormula roundtrip" do
+        quickCheck \(TFormula formula)
+                   -> parseFormula (show formula) `assertEquals` Right formula


### PR DESCRIPTION
Makes the instance of `Show` for `Formula` take precedence and associativity into consideration in order to minimize the use of parentheses.

This pull request also fixes a few issues regarding precedence in the parser.