### PR TITLE
Add initial algorithm for automated ND

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -12,6 +12,7 @@ You can edit this file as you like.
   , "spec"
   , "spec-discovery"
   , "spec-quickcheck"
+  , "debug"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/Formula.purs
+++ b/src/Formula.purs
@@ -8,6 +8,7 @@ module Formula ( Variable(..)
                , disagreementSet
                , unify
                , containsTerm
+               , formulaUnifier
                ) where
 
 import Prelude
@@ -63,6 +64,7 @@ data Formula
   | Exists Variable Formula
 
 derive instance eqFormula :: Eq Formula
+derive instance ordFormula :: Ord Formula
 
 -- | Shows formulas using least amount of parentheses wrt. precedence.
 instance showFormula :: Show Formula where
@@ -194,3 +196,15 @@ containsTerm f t = case f of
   Implies f1 f2    -> containsTerm f1 t || containsTerm f2 t
   Forall x f'      -> containsTerm f' t
   Exists x f'      -> containsTerm f' t
+
+-- | TODO At the moment only works on propositional logic
+formulaUnifier :: Formula -> Formula -> Maybe Substitution
+formulaUnifier = case _, _ of
+  Predicate f args1, Predicate g args2
+    | f == g, Array.length args1 == Array.length args2, Array.length args1 == 0
+      -> Just mempty
+  Not a, Not b -> formulaUnifier a b
+  And a b, And c d -> formulaUnifier a c *> formulaUnifier b d
+  Or a b, Or c d -> formulaUnifier a c *> formulaUnifier b d
+  Implies a b, Implies c d -> formulaUnifier a c *> formulaUnifier b d
+  _, _ -> Nothing

--- a/src/NdAlg.purs
+++ b/src/NdAlg.purs
@@ -7,20 +7,25 @@ module NdAlg (Rule(..), prove) where
 
 import Prelude
 import Data.Array as Array
-import Data.Array ((..), (!!), snoc, unsafeIndex)
+import Data.Array (snoc, slice)
 import Data.Maybe (Maybe(..), maybe', isJust, fromJust)
 import Data.Set (Set)
 import Data.Set as Set
+import Data.FunctorWithIndex (mapWithIndex)
 import Data.Foldable (any, findMap)
-import Util (enumerate, traceShowId)
+import Data.Traversable (mapAccumL)
+import Data.List as List
 import Data.List (List(Nil), (:))
+import Data.NonEmpty as NonEmpty
+import Data.NonEmpty (NonEmpty, (:|))
 import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 import Control.Alternative ((<|>))
 import Control.MonadZero (guard)
-import Data.Lazy (defer, force)
 
 import Formula (Variable(..), Term(..), Formula(..), formulaUnifier)
+import Util (findLast)
 
+-- | The minimal set of elimination and introduction rules.
 data Rule
   = Premise
   | Assumption
@@ -29,77 +34,100 @@ data Rule
   | OrElim Int Int
   | OrIntro
   | NotElim Int
-  | NotIntro
+  | NotIntro Int
   | ImpliesElim Int Int
-  | ImpliesIntro
+  | ImpliesIntro Int
 
 derive instance eqRule :: Eq Rule
 instance showRule :: Show Rule where
   show Premise = "Premise"
   show Assumption = "Assumption"
-  show (AndElim i) = "∧e, " <> show i
+  show (AndElim i) = "∧e " <> show i
   show (AndIntro) = "∧i"
-  show (OrElim i j) = "∨e, " <> show i <> "," <> show j
+  show (OrElim i j) = "∨e " <> show i <> "," <> show j
   show (OrIntro) = "∨i"
-  show (NotElim i) = "¬e, " <> show i
-  show (NotIntro) = "¬i"
-  show (ImpliesElim i j) = "→e, " <> show i <> "," <> show j
-  show (ImpliesIntro) = "→i"
+  show (NotElim i) = "¬e " <> show i
+  show (NotIntro i) = "¬i " <> show i
+  show (ImpliesElim i j) = "→e " <> show i <> "," <> show j
+  show (ImpliesIntro i) = "→i " <> show i
 
--- | A derived formula.
-type Derived = { formula :: Formula, rule :: Rule }
-
-data Goal = False | Goal Formula
+-- | A goal for the proof searching strategy.
+-- |
+-- | Either a formula or two arbitrary contradictory formulae.
+data Goal = Goal Formula | False
 
 derive instance eqGoal :: Eq Goal
+
 instance showGoal :: Show Goal where
   show False = "false"
   show (Goal formula) = show formula
 
+-- | Inclusive-exclusive interval ordered by its left endpoint.
+data Interval = Interval Int Int
+
+instance showInterval :: Show Interval where
+  show (Interval a b) = "[" <> show a <> "," <> show b <> ")"
+
+derive instance eqInterval :: Eq Interval
+
+instance ordInterval :: Ord Interval where
+  compare (Interval a b) (Interval c d) = a `compare` c
+
+-- | Marking scheme to prevent infinite looping.
+type Marks = { elim :: Set Int
+             , complex :: Set Formula }
+
 -- | A partial or completed algorithmic natural deduction derivation.
-type NdAlg = { list_proof :: Array Derived
+type NdAlg = { list_proof :: Array { formula :: Formula, rule :: Rule }
              , list_goals :: List Goal
-             , discarded :: Set Int
-             , markedElim :: Set Int
-             , markedComplex :: Set Formula
+             , discards :: Set Interval
+             , marks :: NonEmpty List Marks -- One for each open nested box
              }
 
-nonDiscardedProofsEnum :: NdAlg -> Array { i :: Int, x :: Derived }
-nonDiscardedProofsEnum { list_proof, discarded }
-  = Array.filter notDiscarded $ enumerate list_proof
+-- | The set of proofs that are not yet discarded.
+nonDiscarded :: NdAlg -> Array { i :: Int, x :: { formula :: Formula, rule :: Rule } }
+nonDiscarded { list_proof, discards }
+  = Array.concatMap
+    (\(Interval a b) -> mapWithIndex (\i x -> { i: i + a, x })
+                        $ slice a b list_proof)
+    nonDiscardedIntervals
   where
-    notDiscarded { i } = not $ i `Set.member` discarded
+    intervals = Set.toUnfoldable discards -- Note: Result is ordered
+    { value: nonDiscardedIntervals }
+      = mapAccumL
+        (\i (Interval a b) -> { accum: max i b, value: Interval i a })
+        0 $ snoc intervals (Interval (Array.length list_proof) 0)
 
-nonDiscardedProofs :: NdAlg -> Array Formula
-nonDiscardedProofs nd = _.x.formula <$> nonDiscardedProofsEnum nd
-
+-- | Reachability status of a current goal.
 goalReached :: Goal -> NdAlg -> Boolean
 goalReached goal nd = case goal of
-  Goal g -> any (isJust <<< formulaUnifier g) proofs
+  Goal g -> any (unifiable g) proofs
   False -> not $ Array.null do
     b <- proofs >>= case _ of Not b -> pure b
                               _ -> []
     a <- proofs
-    guard $ isJust (formulaUnifier a b)
-  where proofs = nonDiscardedProofs nd
+    guard $ unifiable a b
+  where
+    proofs = _.x.formula <$> nonDiscarded nd
+    unifiable a b = isJust $ formulaUnifier a b
 
 findElim :: NdAlg -> Maybe NdAlg
-findElim nd@{ list_proof, list_goals, markedElim }
+findElim nd@{ list_proof, list_goals, marks: marks@(m:|ms) }
   = (\{newProofs, fromProof}
      -> nd { list_proof = list_proof <> newProofs
-           , markedElim = Set.insert fromProof markedElim })
+           , marks = m { elim = Set.insert fromProof m.elim }:|ms })
     <$> findMap considerFormula proofs
   where
-    proofs = nonDiscardedProofsEnum nd
+    proofs = nonDiscarded nd
 
     considerFormula { i, x: {formula: f1} }
       =
         -- If not already considered for elimination
-        if i `Set.member` markedElim then Nothing
+        if any (\{elim} -> i `Set.member` elim) marks then Nothing
         else
           { newProofs: _, fromProof: i } <$> (unaryElim <|> binaryElim)
         where
-          unaryElim :: Maybe (Array Derived)
+          unaryElim :: Maybe (Array { formula :: Formula, rule :: Rule })
           unaryElim = case f1 of
             And a b -> Just [ { formula: a, rule: AndElim i }
                             , { formula: b, rule: AndElim i } ]
@@ -110,7 +138,7 @@ findElim nd@{ list_proof, list_goals, markedElim }
                        (\{i: i2, x: {formula: f2}} -> binaryElimWithFormulas i2 f2)
                        proofs
 
-          binaryElimWithFormulas :: Int -> Formula -> Maybe (Array Derived)
+          binaryElimWithFormulas :: Int -> Formula -> Maybe (Array { formula :: Formula, rule :: Rule })
           binaryElimWithFormulas i2 = case f1, _ of
             Or a b, Not c | a == c -> Just [{ formula: b, rule: OrElim i i2 }]
             Implies a b, c | a == c -> Just [{ formula: b, rule: ImpliesElim i i2 }]
@@ -120,129 +148,98 @@ findElim nd@{ list_proof, list_goals, markedElim }
 doIntro :: NdAlg -> NdAlg
 doIntro nd@{ list_proof
            , list_goals
-           , discarded
-           , markedElim
-           , markedComplex }
+           , discards
+           , marks }
   = case list_goals of
-  -- If successfully proved the first conjunct: Now prove the second
-  Goal _:next@(Goal _:Goal (And _ _):_) -> nd { list_goals = next }
+  -- Do implies-introduction (and discard up till assumption)
+  _:Goal implies@(Implies _ _):next -> let
+    ass = unsafePartial $ fromJust lastAssumption
+    in nd { list_proof = snoc list_proof { formula: implies, rule: ImpliesIntro $ Array.length list_proof - 1 }
+          , list_goals = next
+          , discards = Interval ass.i (Array.length list_proof) `Set.insert` discards
+          , marks = popMarks marks }
 
-  -- Only way we could have reached this goal is by first proving `a` and `b`
-  _:Goal and@(And a b):next
+  -- Proof by contradiction
+  False:next@(Goal _:_) -> let
+    ass = unsafePartial $ fromJust lastAssumption
+    in nd { list_proof = snoc list_proof { formula: Not ass.x.formula, rule: NotIntro $ Array.length list_proof - 1 }
+          , list_goals = next
+          , discards = Interval ass.i (Array.length list_proof) `Set.insert` discards
+          , marks = popMarks marks }
+
+  -- Only way we could have reached this goal is by first proving conjuncts
+  _:Goal and@(And _ _):next
     -> nd { list_proof = snoc list_proof { formula: and, rule: AndIntro }
           , list_goals = next}
 
-  -- Note: →i/¬i will free up any markedElim/Complex whose result gets discarded
-  -- (Can be made less messy by storing in boxes, which are introduced on adding an assumption)
-
-  _:Goal implies@(Implies a b):next -- do implies intro (and discard)
-    -> nd { list_proof = snoc list_proof { formula: implies, rule: ImpliesIntro }
-          , list_goals = next
-          , discarded = discarded `Set.union` unsafePartial (fromJust untilMostRecentAssumption)
-          -- , markedElim = markedElim `Set.difference` unsafePartial (fromJust untilMostRecentAssumption)
-          , markedComplex = markedComplex `Set.difference` unsafePartial (fromJust discardedProofs) }
-
-  -- Proof by contradiction
-  False:next@(Goal a:_)
-    -> nd { list_proof = snoc list_proof { formula: Not (unsafePartial $ fromJust mostRecentAssumption), rule: NotIntro }
-          , list_goals = next
-          , discarded = discarded `Set.union` unsafePartial (fromJust untilMostRecentAssumption)
-                 -- , markedElim = markedElim `Set.difference` unsafePartial (fromJust untilMostRecentAssumption)
-          , markedComplex = markedComplex `Set.difference` unsafePartial (fromJust discardedProofs) }
-
-  _:Goal or@(Or a b):next
+  _:Goal or@(Or _ _):next
     -> nd { list_proof = snoc list_proof { formula: or, rule: OrIntro }
           , list_goals = next}
 
-  -- No applicable introduction rules: Just pop it
+  -- No applicable introduction rules: Just pop goal
   _:next -> nd { list_goals = next }
 
   _ -> unsafeCrashWith $ "not yet implemented: " <> show nd
   where
-    proofs = nonDiscardedProofsEnum nd
-
-    lastAssumption = 0
-
-    mostRecentAssumption = _.x.formula <$> (Array.findLastIndex ((_ == Assumption) <<< _.x.rule) proofs
-                           >>= (proofs !! _))
-
-    discardedProofs
-      = (\is -> Set.mapMaybe ((_.formula <$> _) <<< (list_proof !! _)) is)
-        <$> untilMostRecentAssumption
-
-    untilMostRecentAssumption :: Maybe (Set Int)
-    untilMostRecentAssumption
-      = (\i -> let {i: assIdx} = unsafePartial $ unsafeIndex proofs i
-          in Set.fromFoldable (assIdx..(Array.length list_proof - 1)))
-        <$> Array.findLastIndex (\{x: {rule}} -> rule == Assumption) proofs
+    proofs = nonDiscarded nd
+    lastAssumption = findLast ((_ == Assumption) <<< _.x.rule) proofs
+    -- Panics if we are not in a nested box
+    popMarks :: NonEmpty List Marks -> NonEmpty List Marks
+    popMarks ms
+      = unsafePartial $ fromJust
+        $ (\{head, tail} -> head:|tail) <$> List.uncons (NonEmpty.tail ms)
 
 -- | Tries to prove the specified formula under the given antecedents.
-prove :: Array Formula -> Formula -> Maybe (Array Derived)
+prove :: Array Formula -> Formula -> Maybe (Array { formula :: Formula, rule :: Rule })
 prove premises initialGoal
   = _.list_proof <$> (go $ { list_proof: { formula: _, rule: Premise } <$> premises
-                           , list_goals: Goal initialGoal : Nil
-                           , discarded: Set.empty
-                           , markedElim: Set.empty
-                           , markedComplex: Set.empty })
-  where go nd@{ list_goals: Nil } = Just nd -- No goals means we are finished
-
+                           , list_goals: Goal initialGoal:Nil
+                           , discards: Set.empty
+                           , marks: {elim: Set.empty, complex: Set.empty}:|Nil
+                           })
+  where go nd@{ list_goals: Nil } = Just nd -- No goal means we are finished
         go nd@{ list_goals: goal:_ } | goalReached goal nd = go $ doIntro nd
-
         go nd@{ list_goals: goal:_ }
           = maybe' (\_ -> branchOnCurrentGoal nd goal) go $ findElim nd
 
         -- Procedure 2
-        branchOnCurrentGoal nd@{ list_proof, list_goals, markedComplex }
+        branchOnCurrentGoal nd@{ list_proof, list_goals, marks: marks@(m:|ms) }
           = case _ of
           -- Procedure 2.1
-          -- For elementary quantifier free formula (with negated prop handled below)
+          -- For elementary quantifier free formula (with negation handled below)
           Goal p@(Predicate _ _)
             -> go $ nd { list_proof = snoc list_proof {formula: Not p, rule: Assumption}
-                       , list_goals = False:list_goals }
-          -- ¬A, where A can be a literal, disjunction or exists quantified formula
-          Goal (Not a) | literalDisjunctionOrExists a
+                       , list_goals = False:list_goals
+                       , marks = m:|m:ms }
+          Goal (Not a)
             -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption}
-                       , list_goals = False:list_goals }
-
+                       , list_goals = False:list_goals
+                       , marks = m:|m:ms }
           Goal (And a b) -> go $ nd { list_goals = Goal b:Goal a:list_goals }
           -- Try either disjunct
-          Goal (Or a b) -> findMap force
-                             [ defer \_ -> go $ nd { list_goals = Goal a:list_goals }
-                             , defer \_ -> go $ nd { list_goals = Goal b:list_goals }
-                             , defer \_ -> go $ nd { list_proof = snoc list_proof {formula: Not (Or a b), rule: Assumption}
-                                                   , list_goals = False:list_goals } ]
-
+          Goal (Or a b) -> findMap go
+                             [ nd { list_goals = Goal a:list_goals }
+                             , nd { list_goals = Goal b:list_goals }
+                             , nd { list_proof = snoc list_proof {formula: Not (Or a b), rule: Assumption}
+                                  , list_goals = False:list_goals
+                                  , marks = m:|m:ms } ]
           Goal (Implies a b)
             -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption }
-                       , list_goals = Goal b:list_goals }
-
+                       , list_goals = Goal b:list_goals
+                       , marks = m:|m:ms }
           Goal (Forall α a) -> unsafeCrashWith "not yet implemented"
           Goal (Exists α a) -> unsafeCrashWith "not yet implemented"
 
           -- Procedure 2.2
           False -> let
-            goalFromStructure = case _ of
+            newGoalFrom = case _ of
               Not a -> Just a
               Or a _ -> Just $ Not a
               Implies a _ -> Just a
               _ -> Nothing
-            newGoals
-              = Array.mapMaybe (\{i, x: {formula: f}} -> goalFromStructure f
-                                                         >>= \g -> if g `Set.member` markedComplex
-                                                                   then Nothing
-                                                                   else pure {i, goal: g})
-                $ nonDiscardedProofsEnum nd
-            tryReachGoal {i, goal} = go $ nd { list_goals = Goal goal:list_goals
-                                             , markedComplex = Set.insert goal markedComplex }
-            in findMap tryReachGoal newGoals
-
-          Goal (Not a)
-            -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption}
-                       , list_goals = False:list_goals }
-
-        literalDisjunctionOrExists = case _ of
-          Predicate _ [] -> true
-          Not (Predicate _ []) -> true
-          Or _ _ -> true
-          Exists _ _ -> true
-          _ -> false
+            considerForNewGoal {x: {formula: f}} = do
+              guard $ not $ any (\{complex} -> f `Set.member` complex) marks
+              goal <- newGoalFrom f
+              go $ nd { list_goals = Goal goal:list_goals
+                      , marks = m { complex = f `Set.insert` m.complex }:|ms }
+            in findMap considerForNewGoal $ nonDiscarded nd

--- a/src/NdAlg.purs
+++ b/src/NdAlg.purs
@@ -1,0 +1,248 @@
+-- | This module implements the algorithm for automated first-order
+-- | natural deduction from Bolotov, A., Bocharov, V., Gorchakov, A.,
+-- | & Shangin, V. (2005). Automated first order natural deduction.
+-- | ISCAI.
+
+module NdAlg (Rule(..), prove) where
+
+import Prelude
+import Data.Array as Array
+import Data.Array ((..), (!!), snoc, unsafeIndex)
+import Data.Maybe (Maybe(..), maybe', isJust, fromJust)
+import Data.Set (Set)
+import Data.Set as Set
+import Data.Foldable (any, findMap)
+import Util (enumerate, traceShowId)
+import Data.List (List(Nil), (:))
+import Partial.Unsafe (unsafePartial, unsafeCrashWith)
+import Control.Alternative ((<|>))
+import Control.MonadZero (guard)
+import Data.Lazy (defer, force)
+
+import Formula (Variable(..), Term(..), Formula(..), formulaUnifier)
+
+data Rule
+  = Premise
+  | Assumption
+  | AndElim Int
+  | AndIntro
+  | OrElim Int Int
+  | OrIntro
+  | NotElim Int
+  | NotIntro
+  | ImpliesElim Int Int
+  | ImpliesIntro
+
+derive instance eqRule :: Eq Rule
+instance showRule :: Show Rule where
+  show Premise = "Premise"
+  show Assumption = "Assumption"
+  show (AndElim i) = "∧e, " <> show i
+  show (AndIntro) = "∧i"
+  show (OrElim i j) = "∨e, " <> show i <> "," <> show j
+  show (OrIntro) = "∨i"
+  show (NotElim i) = "¬e, " <> show i
+  show (NotIntro) = "¬i"
+  show (ImpliesElim i j) = "→e, " <> show i <> "," <> show j
+  show (ImpliesIntro) = "→i"
+
+-- | A derived formula.
+type Derived = { formula :: Formula, rule :: Rule }
+
+data Goal = False | Goal Formula
+
+derive instance eqGoal :: Eq Goal
+instance showGoal :: Show Goal where
+  show False = "false"
+  show (Goal formula) = show formula
+
+-- | A partial or completed algorithmic natural deduction derivation.
+type NdAlg = { list_proof :: Array Derived
+             , list_goals :: List Goal
+             , discarded :: Set Int
+             , markedElim :: Set Int
+             , markedComplex :: Set Formula
+             }
+
+nonDiscardedProofsEnum :: NdAlg -> Array { i :: Int, x :: Derived }
+nonDiscardedProofsEnum { list_proof, discarded }
+  = Array.filter notDiscarded $ enumerate list_proof
+  where
+    notDiscarded { i } = not $ i `Set.member` discarded
+
+nonDiscardedProofs :: NdAlg -> Array Formula
+nonDiscardedProofs nd = _.x.formula <$> nonDiscardedProofsEnum nd
+
+goalReached :: Goal -> NdAlg -> Boolean
+goalReached goal nd = case goal of
+  Goal g -> any (isJust <<< formulaUnifier g) proofs
+  False -> not $ Array.null do
+    b <- proofs >>= case _ of Not b -> pure b
+                              _ -> []
+    a <- proofs
+    guard $ isJust (formulaUnifier a b)
+  where proofs = nonDiscardedProofs nd
+
+findElim :: NdAlg -> Maybe NdAlg
+findElim nd@{ list_proof, list_goals, markedElim }
+  = (\{newProofs, fromProof}
+     -> nd { list_proof = list_proof <> newProofs
+           , markedElim = Set.insert fromProof markedElim })
+    <$> findMap considerFormula proofs
+  where
+    proofs = nonDiscardedProofsEnum nd
+
+    considerFormula { i, x: {formula: f1} }
+      =
+        -- If not already considered for elimination
+        if i `Set.member` markedElim then Nothing
+        else
+          { newProofs: _, fromProof: i } <$> (unaryElim <|> binaryElim)
+        where
+          unaryElim :: Maybe (Array Derived)
+          unaryElim = case f1 of
+            And a b -> Just [ { formula: a, rule: AndElim i }
+                            , { formula: b, rule: AndElim i } ]
+            Not (Not a) -> Just [{ formula: a, rule: NotElim i }]
+            _ -> Nothing
+
+          binaryElim = findMap
+                       (\{i: i2, x: {formula: f2}} -> binaryElimWithFormulas i2 f2)
+                       proofs
+
+          binaryElimWithFormulas :: Int -> Formula -> Maybe (Array Derived)
+          binaryElimWithFormulas i2 = case f1, _ of
+            Or a b, Not c | a == c -> Just [{ formula: b, rule: OrElim i i2 }]
+            Implies a b, c | a == c -> Just [{ formula: b, rule: ImpliesElim i i2 }]
+            _, _ -> Nothing
+    -- TODO: forall/exists elim
+
+doIntro :: NdAlg -> NdAlg
+doIntro nd@{ list_proof
+           , list_goals
+           , discarded
+           , markedElim
+           , markedComplex }
+  = case list_goals of
+  -- If successfully proved the first conjunct: Now prove the second
+  Goal _:next@(Goal _:Goal (And _ _):_) -> nd { list_goals = next }
+
+  -- Only way we could have reached this goal is by first proving `a` and `b`
+  _:Goal and@(And a b):next
+    -> nd { list_proof = snoc list_proof { formula: and, rule: AndIntro }
+          , list_goals = next}
+
+  -- Note: →i/¬i will free up any markedElim/Complex whose result gets discarded
+  -- (Can be made less messy by storing in boxes, which are introduced on adding an assumption)
+
+  _:Goal implies@(Implies a b):next -- do implies intro (and discard)
+    -> nd { list_proof = snoc list_proof { formula: implies, rule: ImpliesIntro }
+          , list_goals = next
+          , discarded = discarded `Set.union` unsafePartial (fromJust untilMostRecentAssumption)
+          -- , markedElim = markedElim `Set.difference` unsafePartial (fromJust untilMostRecentAssumption)
+          , markedComplex = markedComplex `Set.difference` unsafePartial (fromJust discardedProofs) }
+
+  -- Proof by contradiction
+  False:next@(Goal a:_)
+    -> nd { list_proof = snoc list_proof { formula: Not (unsafePartial $ fromJust mostRecentAssumption), rule: NotIntro }
+          , list_goals = next
+          , discarded = discarded `Set.union` unsafePartial (fromJust untilMostRecentAssumption)
+                 -- , markedElim = markedElim `Set.difference` unsafePartial (fromJust untilMostRecentAssumption)
+          , markedComplex = markedComplex `Set.difference` unsafePartial (fromJust discardedProofs) }
+
+  _:Goal or@(Or a b):next
+    -> nd { list_proof = snoc list_proof { formula: or, rule: OrIntro }
+          , list_goals = next}
+
+  -- No applicable introduction rules: Just pop it
+  _:next -> nd { list_goals = next }
+
+  _ -> unsafeCrashWith $ "not yet implemented: " <> show nd
+  where
+    proofs = nonDiscardedProofsEnum nd
+
+    lastAssumption = 0
+
+    mostRecentAssumption = _.x.formula <$> (Array.findLastIndex ((_ == Assumption) <<< _.x.rule) proofs
+                           >>= (proofs !! _))
+
+    discardedProofs
+      = (\is -> Set.mapMaybe ((_.formula <$> _) <<< (list_proof !! _)) is)
+        <$> untilMostRecentAssumption
+
+    untilMostRecentAssumption :: Maybe (Set Int)
+    untilMostRecentAssumption
+      = (\i -> let {i: assIdx} = unsafePartial $ unsafeIndex proofs i
+          in Set.fromFoldable (assIdx..(Array.length list_proof - 1)))
+        <$> Array.findLastIndex (\{x: {rule}} -> rule == Assumption) proofs
+
+-- | Tries to prove the specified formula under the given antecedents.
+prove :: Array Formula -> Formula -> Maybe (Array Derived)
+prove premises initialGoal
+  = _.list_proof <$> (go $ { list_proof: { formula: _, rule: Premise } <$> premises
+                           , list_goals: Goal initialGoal : Nil
+                           , discarded: Set.empty
+                           , markedElim: Set.empty
+                           , markedComplex: Set.empty })
+  where go nd@{ list_goals: Nil } = Just nd -- No goals means we are finished
+
+        go nd@{ list_goals: goal:_ } | goalReached goal nd = go $ doIntro nd
+
+        go nd@{ list_goals: goal:_ }
+          = maybe' (\_ -> branchOnCurrentGoal nd goal) go $ findElim nd
+
+        -- Procedure 2
+        branchOnCurrentGoal nd@{ list_proof, list_goals, markedComplex }
+          = case _ of
+          -- Procedure 2.1
+          -- For elementary quantifier free formula (with negated prop handled below)
+          Goal p@(Predicate _ _)
+            -> go $ nd { list_proof = snoc list_proof {formula: Not p, rule: Assumption}
+                       , list_goals = False:list_goals }
+          -- ¬A, where A can be a literal, disjunction or exists quantified formula
+          Goal (Not a) | literalDisjunctionOrExists a
+            -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption}
+                       , list_goals = False:list_goals }
+
+          Goal (And a b) -> go $ nd { list_goals = Goal b:Goal a:list_goals }
+          -- Try either disjunct
+          Goal (Or a b) -> findMap force
+                             [ defer \_ -> go $ nd { list_goals = Goal a:list_goals }
+                             , defer \_ -> go $ nd { list_goals = Goal b:list_goals }
+                             , defer \_ -> go $ nd { list_proof = snoc list_proof {formula: Not (Or a b), rule: Assumption}
+                                                   , list_goals = False:list_goals } ]
+
+          Goal (Implies a b)
+            -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption }
+                       , list_goals = Goal b:list_goals }
+
+          Goal (Forall α a) -> unsafeCrashWith "not yet implemented"
+          Goal (Exists α a) -> unsafeCrashWith "not yet implemented"
+
+          -- Procedure 2.2
+          False -> let
+            goalFromStructure = case _ of
+              Not a -> Just a
+              Or a _ -> Just $ Not a
+              Implies a _ -> Just a
+              _ -> Nothing
+            newGoals
+              = Array.mapMaybe (\{i, x: {formula: f}} -> goalFromStructure f
+                                                         >>= \g -> if g `Set.member` markedComplex
+                                                                   then Nothing
+                                                                   else pure {i, goal: g})
+                $ nonDiscardedProofsEnum nd
+            tryReachGoal {i, goal} = go $ nd { list_goals = Goal goal:list_goals
+                                             , markedComplex = Set.insert goal markedComplex }
+            in findMap tryReachGoal newGoals
+
+          Goal (Not a)
+            -> go $ nd { list_proof = snoc list_proof {formula: a, rule: Assumption}
+                       , list_goals = False:list_goals }
+
+        literalDisjunctionOrExists = case _ of
+          Predicate _ [] -> true
+          Not (Predicate _ []) -> true
+          Or _ _ -> true
+          Exists _ _ -> true
+          _ -> false

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,18 +1,15 @@
 module Util where
 
 import Prelude
+import Data.Array as Array
+import Data.Maybe (Maybe)
+import Partial.Unsafe (unsafePartial)
 import Data.Traversable (mapAccumL, class Traversable)
 import Debug (class DebugWarning, trace)
 
--- | The Haskell '>>' operator.
-semicolon :: forall b a c. Bind b => b a -> b c -> b c
-semicolon a c = do _ <- a
-                   c
-infixl 1 semicolon as >>
-
-enumerate :: forall a f. Traversable f => f a -> f { i :: Int, x :: a }
-enumerate xs = value
-  where { accum, value } = mapAccumL (\s x -> { accum: s + 1, value: { i: s, x } }) 0 xs
+findLast :: forall a. (a -> Boolean) -> Array a -> Maybe a
+findLast f xs = (\i -> unsafePartial $ Array.unsafeIndex xs i)
+                <$> Array.findLastIndex f xs
 
 traceShowId :: forall a. DebugWarning => Show a => a -> a
 traceShowId x = trace (show x) \_ -> x

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,9 +1,18 @@
 module Util where
 
 import Prelude
+import Data.Traversable (mapAccumL, class Traversable)
+import Debug (class DebugWarning, trace)
 
 -- | The Haskell '>>' operator.
 semicolon :: forall b a c. Bind b => b a -> b c -> b c
 semicolon a c = do _ <- a
                    c
 infixl 1 semicolon as >>
+
+enumerate :: forall a f. Traversable f => f a -> f { i :: Int, x :: a }
+enumerate xs = value
+  where { accum, value } = mapAccumL (\s x -> { accum: s + 1, value: { i: s, x } }) 0 xs
+
+traceShowId :: forall a. DebugWarning => Show a => a -> a
+traceShowId x = trace (show x) \_ -> x

--- a/test/Formula.purs
+++ b/test/Formula.purs
@@ -13,7 +13,7 @@ import Data.NonEmpty (NonEmpty(NonEmpty))
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Set as Set
 import Data.Foldable (fold)
-import Data.Maybe (Maybe(..), fromJust)
+import Data.Maybe (Maybe(..), fromJust, isJust)
 import Data.Either (Either(Right))
 import Data.Tuple (Tuple(..))
 import Data.Traversable (sequence)
@@ -25,7 +25,7 @@ import Data.Char as Char
 import Data.String.CodeUnits as CU
 
 import Formula (Term(..), Variable(..), Formula(..), singleSub, substitute,
-                disagreementSet, unify)
+                disagreementSet, unify, formulaUnifier)
 import Parser (parseFormula)
 
 -- | Generator for a single uppercase letter string.
@@ -156,3 +156,7 @@ spec = describe "Formulas" do
       it "should survive show/parseFormula roundtrip" do
         quickCheck \(TFormula formula)
                    -> parseFormula (show formula) `assertEquals` Right formula
+
+      it "can unify and formula" do
+        let formula = And (Predicate "A" []) (Predicate "B" [])
+        (isJust $ formulaUnifier formula formula) `shouldEqual` true

--- a/test/NdAlg.purs
+++ b/test/NdAlg.purs
@@ -23,26 +23,44 @@ spec = describe "Automated ND" do
                          , { formula: readFormula "¬P", rule: Assumption }
                          , { formula: readFormula "P", rule: Assumption }
                          , { formula: readFormula "¬Q", rule: Assumption }
-                         , { formula: readFormula "¬¬Q", rule: NotIntro }
+                         , { formula: readFormula "¬¬Q", rule: NotIntro 3 }
                          , { formula: readFormula "Q", rule: NotElim 4 }
-                         , { formula: readFormula "P → Q", rule: ImpliesIntro }
+                         , { formula: readFormula "P → Q", rule: ImpliesIntro 5 }
                          , { formula: readFormula "P", rule: ImpliesElim 0 6 }
-                         , { formula: readFormula "¬¬P", rule: NotIntro }
+                         , { formula: readFormula "¬¬P", rule: NotIntro 7 }
                          , { formula: readFormula "P", rule: NotElim 8 }
-                         , { formula: readFormula "((P → Q) → P) → P", rule: ImpliesIntro }
-                         ]
+                         , { formula: readFormula "((P → Q) → P) → P", rule: ImpliesIntro 9 } ]
 
-  it "should be able to do shit" do
-    prove [readFormula "P∨Q"] (readFormula "¬P→Q") `shouldEqual` Nothing
+  it "should prove modus tollens" do
+    prove [readFormula "P → Q", readFormula "¬Q"]
+      (readFormula "¬P")
+      `shouldEqual` Just [ { formula: readFormula "P → Q", rule: Premise }
+                         , { formula: readFormula "¬Q", rule: Premise }
+                         , { formula: readFormula "P", rule: Assumption }
+                         , { formula: readFormula "Q", rule: ImpliesElim 0 2 }
+                         , { formula: readFormula "¬P", rule: NotIntro 3 } ]
+
+  it "should determine that no ND proof can be found" do
+    prove [readFormula "P"] (readFormula "Q") `shouldEqual` Nothing
+
+    -- Commented out because it takes ~5 seconds
+    -- prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→V)") `shouldEqual` Nothing
+
   it "should be able to do hard shit" do
     prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→S)") `shouldEqual` Nothing
 
-  -- This one takes a long ass time to finish.
-  -- it "should be able to do hard shit v2" do
-    -- prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→V)") `shouldEqual` Nothing
-
   it "should prove De Morgan's" do
-    prove [readFormula "¬(A ∧ B)"] (readFormula "¬A ∨ ¬B") `shouldEqual` Nothing
-
-  it "should prove De Morgan's v2" do
-    prove [readFormula "¬A ∨ ¬B"] (readFormula "¬(A ∧ B)") `shouldEqual` Nothing
+    prove [readFormula "¬(A ∧ B)"] (readFormula "¬A ∨ ¬B")
+      `shouldEqual` Just [ { formula: readFormula "¬(A ∧ B)", rule: Premise }
+                         , { formula: readFormula "¬(¬A ∨ ¬B)", rule: Assumption }
+                         , { formula: readFormula "¬B", rule: Assumption }
+                         , { formula: readFormula "¬A ∨ ¬B", rule: OrIntro }
+                         , { formula: readFormula "¬¬B", rule: NotIntro 3 }
+                         , { formula: readFormula "B", rule: NotElim 4 }
+                         , { formula: readFormula "¬A", rule: Assumption }
+                         , { formula: readFormula "¬A ∨ ¬B", rule: OrIntro }
+                         , { formula: readFormula "¬¬A", rule: NotIntro 7 }
+                         , { formula: readFormula "A", rule: NotElim 8 }
+                         , { formula: readFormula "A ∧ B", rule: AndIntro }
+                         , { formula: readFormula "¬¬(¬A ∨ ¬B)", rule: NotIntro 10 }
+                         , { formula: readFormula "¬A ∨ ¬B", rule: NotElim 11 } ]

--- a/test/NdAlg.purs
+++ b/test/NdAlg.purs
@@ -40,27 +40,52 @@ spec = describe "Automated ND" do
                          , { formula: readFormula "Q", rule: ImpliesElim 0 2 }
                          , { formula: readFormula "¬P", rule: NotIntro 3 } ]
 
+  it "should prove law of excluded middle" do
+    prove [] (readFormula "A ∨ ¬A")
+      `shouldEqual` Just [ { formula: readFormula "¬(A ∨ ¬A)", rule: Assumption }
+                         , { formula: readFormula "A", rule: Assumption }
+                         , { formula: readFormula "(A ∨ ¬A)", rule: OrIntro }
+                         , { formula: readFormula "¬A", rule: NotIntro 2 }
+                         , { formula: readFormula "¬A", rule: Assumption }
+                         , { formula: readFormula "(A ∨ ¬A)", rule: OrIntro }
+                         , { formula: readFormula "¬¬A", rule: NotIntro 5 }
+                         , { formula: readFormula "¬¬(A ∨ ¬A)", rule: NotIntro 6 }
+                         , { formula: readFormula "(A ∨ ¬A)", rule: NotElim 7 } ]
+
   it "should determine that no ND proof can be found" do
     prove [readFormula "P"] (readFormula "Q") `shouldEqual` Nothing
+
+  -- it "should be able to do hard shit" do
+    -- prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→S)") `shouldEqual` Nothing
 
     -- Commented out because it takes ~5 seconds
     -- prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→V)") `shouldEqual` Nothing
 
-  it "should be able to do hard shit" do
-    prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→S)") `shouldEqual` Nothing
+  -- This one does not work (never terminates)
+  -- it "should be able to do very hard shit" do
+    -- prove [] (readFormula "(P∧Q)∨(P∧¬Q)∨(¬P∧Q)∨(¬P∧¬Q)") `shouldEqual` Nothing
 
   it "should prove De Morgan's" do
     prove [readFormula "¬(A ∧ B)"] (readFormula "¬A ∨ ¬B")
       `shouldEqual` Just [ { formula: readFormula "¬(A ∧ B)", rule: Premise }
                          , { formula: readFormula "¬(¬A ∨ ¬B)", rule: Assumption }
-                         , { formula: readFormula "¬B", rule: Assumption }
-                         , { formula: readFormula "¬A ∨ ¬B", rule: OrIntro }
-                         , { formula: readFormula "¬¬B", rule: NotIntro 3 }
-                         , { formula: readFormula "B", rule: NotElim 4 }
                          , { formula: readFormula "¬A", rule: Assumption }
                          , { formula: readFormula "¬A ∨ ¬B", rule: OrIntro }
-                         , { formula: readFormula "¬¬A", rule: NotIntro 7 }
-                         , { formula: readFormula "A", rule: NotElim 8 }
+                         , { formula: readFormula "¬¬A", rule: NotIntro 3 }
+                         , { formula: readFormula "A", rule: NotElim 4 }
+                         , { formula: readFormula "¬B", rule: Assumption }
+                         , { formula: readFormula "¬A ∨ ¬B", rule: OrIntro }
+                         , { formula: readFormula "¬¬B", rule: NotIntro 7 }
+                         , { formula: readFormula "B", rule: NotElim 8 }
                          , { formula: readFormula "A ∧ B", rule: AndIntro }
                          , { formula: readFormula "¬¬(¬A ∨ ¬B)", rule: NotIntro 10 }
                          , { formula: readFormula "¬A ∨ ¬B", rule: NotElim 11 } ]
+    prove [readFormula "¬A ∨ ¬B"] (readFormula "¬(A ∧ B)")
+      `shouldEqual` Just [ { formula: readFormula "¬A ∨ ¬B", rule: Premise }
+                         , { formula: readFormula "A ∧ B", rule: Assumption }
+                         , { formula: readFormula "A", rule: AndElim 1 }
+                         , { formula: readFormula "B", rule: AndElim 1 }
+                         , { formula: readFormula "¬A", rule: Assumption }
+                         , { formula: readFormula "¬¬A", rule: NotIntro 4 }
+                         , { formula: readFormula "¬B", rule: OrElim 0 5 }
+                         , { formula: readFormula "¬(A ∧ B)", rule: NotIntro 6 } ]

--- a/test/NdAlg.purs
+++ b/test/NdAlg.purs
@@ -1,0 +1,48 @@
+module Test.NdAlg where
+
+import Prelude
+import Data.Maybe (Maybe(..))
+import Data.Either (fromRight')
+import Partial.Unsafe (unsafeCrashWith)
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+import NdAlg (Rule(..), prove)
+import Formula (Formula)
+import Parser (parseFormula)
+
+readFormula :: String -> Formula
+readFormula s = fromRight' (\_ -> unsafeCrashWith "Bad formula")
+                $ parseFormula s
+
+spec :: Spec Unit
+spec = describe "Automated ND" do
+  it "should prove Peirce's law" do
+    prove [] (readFormula "((P → Q) → P) → P")
+      `shouldEqual` Just [ { formula: readFormula "(P → Q) → P", rule: Assumption }
+                         , { formula: readFormula "¬P", rule: Assumption }
+                         , { formula: readFormula "P", rule: Assumption }
+                         , { formula: readFormula "¬Q", rule: Assumption }
+                         , { formula: readFormula "¬¬Q", rule: NotIntro }
+                         , { formula: readFormula "Q", rule: NotElim 4 }
+                         , { formula: readFormula "P → Q", rule: ImpliesIntro }
+                         , { formula: readFormula "P", rule: ImpliesElim 0 6 }
+                         , { formula: readFormula "¬¬P", rule: NotIntro }
+                         , { formula: readFormula "P", rule: NotElim 8 }
+                         , { formula: readFormula "((P → Q) → P) → P", rule: ImpliesIntro }
+                         ]
+
+  it "should be able to do shit" do
+    prove [readFormula "P∨Q"] (readFormula "¬P→Q") `shouldEqual` Nothing
+  it "should be able to do hard shit" do
+    prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→S)") `shouldEqual` Nothing
+
+  -- This one takes a long ass time to finish.
+  -- it "should be able to do hard shit v2" do
+    -- prove [readFormula "(P∧Q)→(R∨S)"] (readFormula "(P→R)∨(Q→V)") `shouldEqual` Nothing
+
+  it "should prove De Morgan's" do
+    prove [readFormula "¬(A ∧ B)"] (readFormula "¬A ∨ ¬B") `shouldEqual` Nothing
+
+  it "should prove De Morgan's v2" do
+    prove [readFormula "¬A ∨ ¬B"] (readFormula "¬(A ∧ B)") `shouldEqual` Nothing


### PR DESCRIPTION
Än så länge fungerar den bara för propositional logic och dessutom terminerar den inte på inputs som `(P∧Q)∨(P∧¬Q)∨(¬P∧Q)∨(¬P∧¬Q)`, så det är saker som vi kan behöva fixa så småningom.