### PR TITLE
gui rules panel

### DIFF
--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -10,13 +10,12 @@ import Data.Set as Set
 import Data.Set (Set)
 import Data.FoldableWithIndex (foldlWithIndex)
 import Data.List as List
-
 import Data.List (List(Nil), (:))
-import Data.Maybe (Maybe(..), fromJust, maybe)
+import Data.Maybe (Maybe(..), fromJust, maybe, isJust)
+import Data.Either
 import Data.NonEmpty (NonEmpty, (:|))
 import Data.MediaType (MediaType(MediaType))
 import Data.Int as Int
-
 import Data.NonEmpty as NonEmpty
 import Halogen as H
 import Halogen.HTML as HH
@@ -27,13 +26,14 @@ import Web.HTML.Event.DragEvent as DragEvent
 import Web.HTML.Event.DragEvent (DragEvent)
 import Web.HTML.Event.DataTransfer as DataTransfer
 import Web.HTML.HTMLElement as HTMLElement
-
 import Util (moveWithin)
 import GUI.SymbolInput as SI
 import GUI.SymbolInput (symbolInput)
 import GUI.Rules as R
 import Partial.Unsafe (unsafeCrashWith, unsafePartial)
 import Type.Proxy (Proxy(..))
+import Formula
+import Parser
 
 -- For GUI proof state we use a representation that is easy to modify,
 -- i.e. has a single contiguous array of all rows. When rendering or
@@ -53,24 +53,31 @@ ruleText (Assumption _) = "Ass."
 
 type ProofRow
   = { formulaText :: String
-    , rule :: Rule
-    , ruleArgs :: Array String
+    {- For elimination rules we need to be able to inspect the formula and extract the
+       components that we need from it. This will be nothing if the formula in the field
+       is either empty or ill-formed.
+       The idea is that if this field is Nothing and the formulaText is not empty, we can
+       do something to signal to the user that the formula is ill-formed. Red text is not
+       visible for everyone, so perhaps something else. -}
+    , formulaIR   :: Maybe Formula
+    , rule        :: Rule
+    , ruleArgs    :: Array String
     }
 
 -- | A newly added row.
 emptyRow :: ProofRow
-emptyRow = { formulaText: "", rule: Rule "", ruleArgs: [] }
+emptyRow = { formulaText: "", formulaIR: Nothing, rule: Rule "", ruleArgs: [] }
 
 -- | Only stores endpoints of boxes since assumptions naturally define start points.
 type State
-  = { premises :: String
-    , conclusion :: String
-    , rows :: Array ProofRow
+  = { premises     :: String
+    , conclusion   :: String
+    , rows         :: Array ProofRow
     , draggingOver :: Maybe Int
-    , boxEnds :: Set Int
-    , expectsArgs :: Int
-    , clicked :: Array Int
-    , clickedRule :: Maybe R.Rules
+    , boxEnds      :: Set Int
+    , expectsArgs  :: Int            -- How many more operands needs to be selected
+    , clicked      :: Array Int      -- Which operands have already been selected
+    , clickedRule  :: Maybe R.Rules  -- The rule that we want to apply the operands to
     }
 
 data Action
@@ -83,6 +90,13 @@ data Action
   | DragLeave Int DragEvent
   | DragEnd Int DragEvent
   | Drop Int DragEvent
+  {- Just to have something that works for now I have made it so that a user selects
+     the operands to apply to a rule by clicking the row number. This action will notify
+     the handleAction function which row was clicked. Perhaps this is not optimal, but
+     this is a prototype so it can always be changed for something more suitable later.
+     
+     Ideally the number would be highlighted or something if you hover over it, to signal
+     to the user that it can be clicked, but right now nothing happens. Those who know, knows! -}
   | ClickedRow Int
 
 _symbolInput = Proxy :: Proxy "symbolInput"
@@ -107,25 +121,45 @@ proof =
             , handleQuery = handleQuery
             }
     }
-initialState _ = { premises: ""
-                 , conclusion: ""
-                 , rows: [ emptyRow ]
-                 , draggingOver: Nothing
-                 , boxEnds: Set.empty
-                 , expectsArgs: 0
-                 , clicked: []
-                 , clickedRule: Nothing}
 
---handleQuery :: forall a action output m. MonadEffect m => Query a -> H.HalogenM State action Slots output m (Maybe a)
+initialState _ =
+  { premises: ""
+  , conclusion: ""
+  , rows: [ emptyRow ]
+  , draggingOver: Nothing
+  , boxEnds: Set.empty
+  , expectsArgs: 0
+  , clicked: []
+  , clickedRule: Nothing
+  }
+
+-- When we end up here a button has been clicked in the rules panel
 handleQuery (Tell command a) = case command of
   R.AndElim1 -> do
     H.liftEffect $ logShow "and elim 1"
-    -- When we are here the button click from AndElim1 has been propagated all
-    -- the way to the proof component, and we can now update the state accordingly,
-    -- inserting new rows etc.
+    {- When we enter one of these cases the user has chosen to apply a rule. However,
+       we don't yet know which operands to apply the rule to. We modify the state to
+       remember which rule was clicked and how many operands is required.
+       
+       Perhaps when we enter a state like this, all the other functionality in the
+       editor could be disabled until the right amount of operands have been selected.
+       Nothing stops a user from initiating an and introduction and then initiating an
+       and elimination before the and introduction is complete. -}
+    H.modify_ \st ->
+      st
+        { expectsArgs = 1
+        , clicked = []
+        , clickedRule = Just R.AndElim1
+        }
     pure Nothing
   R.AndElim2 -> do
     H.liftEffect $ logShow "and elim 2"
+    H.modify_ \st ->
+      st
+        { expectsArgs = 1
+        , clicked = []
+        , clickedRule = Just R.AndElim2
+        }
     pure Nothing
   R.AndIntro -> do
     H.liftEffect $ logShow "and introduction"
@@ -149,7 +183,7 @@ handleQuery (Tell command a) = case command of
     H.liftEffect $ logShow "not intro"
     H.modify_ \st ->
       st
-        { expectsArgs = 1
+        { expectsArgs = 1 -- Actually this should be applied to a box and not just an operand, but I don't know how to do this now
         , clicked = []
         , clickedRule = Just R.NotIntro
         }
@@ -158,7 +192,7 @@ handleQuery (Tell command a) = case command of
     H.liftEffect $ logShow "not elim"
     H.modify_ \st ->
       st
-        { expectsArgs = 1
+        { expectsArgs = 1 -- Same as for not intro, should be a box
         , clicked = []
         , clickedRule = Just R.NotElim
         }
@@ -197,35 +231,51 @@ render st =
       )
       .elems
   where
-    row :: Int -> ProofRow -> HH.HTML _ _
-    row i { formulaText, rule, ruleArgs }
-      = HH.div
-        [ HP.classes ([ HH.ClassName "columns", HH.ClassName "is-mobile", HH.ClassName "proof-row" ]
-                      <> maybe [] (\j -> if i == j then [ HH.ClassName "dragged-over" ]
-                                         else []) st.draggingOver)
-        , HP.draggable true
-        , HE.onDragStart $ DragStart i
-        , HE.onDragOver $ DragOver i
-        , HE.onDragEnter $ DragEnter i
-        , HE.onDragLeave $ DragLeave i
-        , HE.onDrop $ Drop i
-        , HE.onDragEnd $ DragEnd i ]
-        ( [ HH.div
-              [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
-              [ HH.h4
-                  [ HP.classes [ HH.ClassName "title", HH.ClassName "row-index" ], HE.onClick \_ -> ClickedRow i ]
-                  [ HH.text (show (1+i)) ]
-              ]
-          , HH.div
-              [ HP.classes [ HH.ClassName "column", HH.ClassName "formula-field" ] ]
-              [ HH.slot _symbolInput (2*i) (symbolInput "Enter formula") formulaText $ case _ of
-                   SI.NewValue s -> UpdateFormula i s
-                   SI.EnterPressed -> NewRowBelow i
-              ]
-          , HH.div
-              [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
-              [ HH.span
+  row :: Int -> ProofRow -> HH.HTML _ _
+  row i { formulaText, formulaIR, rule, ruleArgs } =
+    HH.div
+      [ HP.classes
+          ( [ HH.ClassName "columns", HH.ClassName "is-mobile", HH.ClassName "proof-row" ]
+              <> maybe []
+                  ( \j ->
+                      if i == j then
+                        [ HH.ClassName "dragged-over" ]
+                      else
+                        []
+                  )
+                  st.draggingOver
+          )
+      , HP.draggable true
+      , HE.onDragStart $ DragStart i
+      , HE.onDragOver $ DragOver i
+      , HE.onDragEnter $ DragEnter i
+      , HE.onDragLeave $ DragLeave i
+      , HE.onDrop $ Drop i
+      , HE.onDragEnd $ DragEnd i
+      ]
+      ( [ HH.div
+            [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
+            [ HH.h4
+                [ HP.classes [ HH.ClassName "title", HH.ClassName "row-index" ]
+                  {- You click on this number to select the formula in this row as an
+                     operand. -}
+                , HE.onClick \_ -> ClickedRow i
+                ]
+                [ HH.text (show (1 + i)) ]
+            ]
+        , HH.div
+            [ HP.classes [ HH.ClassName "column", HH.ClassName "formula-field" ] ]
+            [ HH.slot _symbolInput (2 * i) (symbolInput "Enter formula") formulaText
+                $ case _ of
+                    SI.NewValue s -> UpdateFormula i s
+                    SI.EnterPressed -> NewRowBelow i
+            ]
+        , HH.div
+            [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
+            [ HH.span
                 [ HP.classes [ HH.ClassName "rule-field" ] ]
+                {- The rule text field must now indicate not only the rule that was applied,
+                   but also the rownumbers of the operands it was applied to. -}
                 [ HH.slot _symbolInput (2 * i + 1) (symbolInput "Rule") (ruleText rule <> " " <> renderArgs ruleArgs)
                     $ case _ of
                         SI.NewValue s -> UpdateRule i s
@@ -235,8 +285,8 @@ render st =
         ]
       )
 
-    renderArgs :: Array String -> String
-    renderArgs args = Array.intercalate ", " args
+  renderArgs :: Array String -> String
+  renderArgs args = Array.intercalate ", " args
 
 -- | The media type for the index of a proof row as a string.
 rowMediaType :: MediaType
@@ -244,22 +294,42 @@ rowMediaType = MediaType "application/x.row"
 
 handleAction :: forall output m. MonadEffect m => Action -> H.HalogenM State Action Slots output m Unit
 handleAction = case _ of
+  -- This gigantic case is run when a user has selected an operand
   ClickedRow i -> do
     H.liftEffect $ logShow $ "clicked row: " <> show i
     st <- H.get
+    -- If this is _not_ the final operand, we just update the state accordingly (look below, in the then)
     if st.expectsArgs > 0 then
+      -- If this is the last operand, however, we are ready to apply a rule and create a new row
       if st.expectsArgs == 1 then case st.clickedRule of
         Just R.AndIntro ->
           let
             h1 = unsafePartial $ fromJust $ Array.head $ st.clicked
 
-            f1 = (unsafePartial $ fromJust $ Array.index st.rows h1).formulaText
+            row1 = fetchRow st h1
 
-            f2 = (unsafePartial $ fromJust $ Array.index st.rows i).formulaText
+            row2 = fetchRow st i
 
-            newrow = { formulaText: f1 <> " ∧ " <> f2, rule: Rule "∧i", ruleArgs: [ show (h1 + 1), show (i + 1) ] }
+            {- Right now it is assumed that the selected operands are well-formed (and thus
+               also parsed correctly), but we should actually have a check here to make sure
+               that the operands are OK. We can and-intro any two formulas so we don't need to
+               inspect what the formulas actually are. -}
+            ir1 = unsafePartial $ fromJust $ row1.formulaIR
+
+            ir2 = unsafePartial $ fromJust $ row2.formulaIR
+
+            formula = And ir1 ir2
+
+            newrow =
+              { formulaText: show formula
+              , formulaIR: Just formula
+              , rule: Rule "∧i"
+              , ruleArgs: [ show (h1 + 1), show (i + 1) ]
+              }
           in
             do
+              {- When we add the new row we have finished applying a rule, so we need to
+                 also modify the state to not expect more operands etc. -}
               H.modify_ \st ->
                 st
                   { expectsArgs = 0
@@ -272,14 +342,26 @@ handleAction = case _ of
           let
             h1 = unsafePartial $ fromJust $ Array.head $ st.clicked
 
-            f1 = (unsafePartial $ fromJust $ Array.index st.rows h1).formulaText
+            row1 = fetchRow st h1
 
-            f2 = (unsafePartial $ fromJust $ Array.index st.rows i).formulaText
+            row2 = fetchRow st i
 
-            -- This might be a little weird, will user actually apply OrIntro to a couple of rows? Isn't it usually so that you can pick anything to be introduced on the one of the sides of an OrIntro - i.e. 
-            -- row 1   A                Premise
-            ---row 2   A ∨ "anything"   ∨i, 1
-            newrow = { formulaText: f1 <> " ∨ " <> f2, rule: Rule "∨i", ruleArgs: [ show (h1 + 1), show (i + 1) ] }
+            ir1 = unsafePartial $ fromJust $ row1.formulaIR
+
+            ir2 = unsafePartial $ fromJust $ row2.formulaIR
+
+            formula = Or ir1 ir2
+
+            {- This might be a little weird, will user actually apply OrIntro to a couple of rows? Isn't it usually so that you can pick anything to be introduced on the one of the sides of an OrIntro -
+            i.e. 
+             row 1   A                Premise
+             row 2   A ∨ "anything"   ∨i, 1 -}
+            newrow =
+              { formulaText: show formula -- not sure if this renders properly, lack of parentheses
+              , formulaIR: Just formula
+              , rule: Rule "∨i"
+              , ruleArgs: [ show (h1 + 1), show (i + 1) ]
+              }
           in
             do
               H.modify_ \st ->
@@ -291,9 +373,20 @@ handleAction = case _ of
                   }
         Just R.NotIntro ->
           let
-            f1 = (unsafePartial $ fromJust $ Array.index st.rows i).formulaText
+            row = fetchRow st i
 
-            newrow = { formulaText: "¬" <> f1, rule: Rule "¬i", ruleArgs: [ show (i + 1) ] }
+            f = row.formulaText
+
+            ir = unsafePartial $ fromJust $ row.formulaIR
+
+            formula = Not ir
+
+            newrow =
+              { formulaText: show formula
+              , formulaIR: Just formula
+              , rule: Rule "¬i"
+              , ruleArgs: [ show (i + 1) ]
+              }
           in
             do
               H.modify_ \st ->
@@ -303,7 +396,57 @@ handleAction = case _ of
                   , clickedRule = Nothing
                   , rows = Array.snoc st.rows newrow
                   }
-        --Just R.NotElim -> ??? Not sure how to do this, which might mean that actually the previous rows where not done in a suitable way either. We probably need to find out what the new formulaText will be by "actually applying the rule to a formula" - but how??
+        Just R.AndElim1 -> do
+          st <- H.get
+          let
+            row = fetchRow st i
+          {- When we apply the elimination rules we need to check that we are performing
+             valid eliminations. In this example, to perform an and elimination the operand has
+             to be a conjunction. -}
+          case row.formulaIR of
+            Just (And e1 _) ->
+              let
+                newrow =
+                  { formulaText: show e1
+                  , formulaIR: Just e1
+                  , rule: Rule "∧e1"
+                  , ruleArgs: [ show (i + 1) ]
+                  }
+              in
+                H.modify_ \st ->
+                  st
+                    { expectsArgs = 0
+                    , clicked = []
+                    , clickedRule = Nothing
+                    , rows = Array.snoc st.rows newrow
+                    }
+            -- This is when someone tries to and-elim something that is not a conjunction
+            Just _ -> pure unit
+            -- This is when someone tries to and-elim an illformed formula. We should report errors here.
+            Nothing -> pure unit
+        Just R.AndElim2 -> do
+          st <- H.get
+          let
+            row = fetchRow st i
+          case row.formulaIR of
+            Just (And _ e2) ->
+              let
+                newrow =
+                  { formulaText: show e2
+                  , formulaIR: Just e2
+                  , rule: Rule "∧e2"
+                  , ruleArgs: [ show (i + 1) ]
+                  }
+              in
+                H.modify_ \st ->
+                  st
+                    { expectsArgs = 0
+                    , clicked = []
+                    , clickedRule = Nothing
+                    , rows = Array.snoc st.rows newrow
+                    }
+            Just _ -> pure unit
+            Nothing -> pure unit
         _ -> pure unit
       else
         H.modify_ \st ->
@@ -312,9 +455,23 @@ handleAction = case _ of
             , clicked = Array.snoc st.clicked i
             }
     else
+      -- If the user clicked an operand when we are not expecting any we just don't do anything
       pure unit
-  UpdateFormula i s ->
-    H.modify_ \st -> st { rows = unsafePartial $ fromJust $ Array.modifyAt i _ { formulaText = s } st.rows }
+  UpdateFormula i s -> do
+    st <- H.get
+    let
+      row = unsafePartial $ fromJust $ Array.index st.rows i
+    case parseFormula s of
+      Left err ->
+        let
+          newrows = myupdateAt i st.rows (row { formulaText = s, formulaIR = Nothing })
+        in
+          H.modify_ \st -> st { rows = newrows }
+      Right formula ->
+        let
+          newrows = myupdateAt i st.rows (row { formulaText = s, formulaIR = Just formula })
+        in
+          H.modify_ \st -> st { rows = newrows }
   UpdateRule i s ->
     H.modify_ \st ->
       st
@@ -338,8 +495,7 @@ handleAction = case _ of
               $ incrBoxEnds st.rows
           }
     -- Focus the newly added row
-    H.tell _symbolInput (2*(i+1)) SI.Focus
-
+    H.tell _symbolInput (2 * (i + 1)) SI.Focus
   DragStart i ev -> do
     H.liftEffect $ DataTransfer.setData rowMediaType (show i)
       $ DragEvent.dataTransfer ev
@@ -362,40 +518,47 @@ handleAction = case _ of
   Drop i ev -> do
     H.liftEffect $ Event.preventDefault $ DragEvent.toEvent ev
     H.modify_ \st -> st { draggingOver = Nothing }
-
     { start, end } <- draggedRows ev
-    H.modify_
-      \st -> let
+    H.modify_ \st ->
+      let
         target = i + 1
+
         newStart = target - if start < target then end - start else 0
 
-        updateBoxes = mapWithIndex \j -> case _ of
-          row@{ rule: Assumption { boxEndIdx } }
-            | start <= j, j < end -- Moved box
-              -> row { rule = Assumption { boxEndIdx: boxEndIdx + (newStart - start) }}
-            | i <= boxEndIdx, boxEndIdx < start -- Move before/inside box
-              -> row { rule = Assumption { boxEndIdx: boxEndIdx + (end - start) }}
-            | start <= boxEndIdx, boxEndIdx < i -- Move after box
-              -> row { rule = Assumption { boxEndIdx: boxEndIdx - (end - start) }}
-          x -> x
+        updateBoxes =
+          mapWithIndex \j -> case _ of
+            row@{ rule: Assumption { boxEndIdx } }
+              | start <= j, j < end -> row { rule = Assumption { boxEndIdx: boxEndIdx + (newStart - start) } }
+              | i <= boxEndIdx, boxEndIdx < start -> row { rule = Assumption { boxEndIdx: boxEndIdx + (end - start) } }
+              | start <= boxEndIdx, boxEndIdx < i -> row { rule = Assumption { boxEndIdx: boxEndIdx - (end - start) } }
+            x -> x
 
         rows' = moveWithin target start end $ updateBoxes st.rows
-        in st { rows = rows' }
+      in
+        st { rows = rows' }
   where
-    -- | Inclusive-exclusive interval of the rows that are currently being dragged.
-    draggedRows :: DragEvent -> H.HalogenM _ _ _ _ _ { start :: Int, end :: Int }
-    draggedRows ev = do
-      start <- (\s -> unsafePartial $ fromJust $ Int.fromString s)
-               <$> (H.liftEffect $ DataTransfer.getData rowMediaType $ DragEvent.dataTransfer ev)
-      rows <- H.gets _.rows
-      let startRow = unsafePartial $ fromJust $ rows !! start
-      let end = case startRow.rule of
-            Rule _ -> start + 1
-            Assumption { boxEndIdx } -> boxEndIdx + 1
-      pure { start, end }
+  -- | Inclusive-exclusive interval of the rows that are currently being dragged.
+  draggedRows :: DragEvent -> H.HalogenM _ _ _ _ _ { start :: Int, end :: Int }
+  draggedRows ev = do
+    start <-
+      (\s -> unsafePartial $ fromJust $ Int.fromString s)
+        <$> (H.liftEffect $ DataTransfer.getData rowMediaType $ DragEvent.dataTransfer ev)
+    rows <- H.gets _.rows
+    let
+      startRow = unsafePartial $ fromJust $ rows !! start
+    let
+      end = case startRow.rule of
+        Rule _ -> start + 1
+        Assumption { boxEndIdx } -> boxEndIdx + 1
+    pure { start, end }
 
-    isValidDropZone i ev = (\{ start, end } -> not (start <= i && i < end)) <$> draggedRows ev
+  isValidDropZone i ev = (\{ start, end } -> not (start <= i && i < end)) <$> draggedRows ev
 
+  -- I hate writing so many unsafePartial $ fromJust's
+  fetchRow st row = unsafePartial $ fromJust $ Array.index st.rows row
+
+  myupdateAt :: forall a. Int -> Array a -> a -> Array a
+  myupdateAt i arr a = unsafePartial $ fromJust $ Array.updateAt i a arr
 
 ruleFromString :: String -> Int -> Rule
 ruleFromString s rowIdx

--- a/src/GUI/Rules.purs
+++ b/src/GUI/Rules.purs
@@ -9,3 +9,6 @@ to differentiate between clicks on different buttons.
 data Rules = AndElim1
            | AndElim2
            | AndIntro
+           | OrIntro
+           | NotIntro
+           | NotElim

--- a/src/GUI/Rules.purs
+++ b/src/GUI/Rules.purs
@@ -6,9 +6,10 @@ indicate what operands to apply a rule to. When we click a button in the GUI we
 don't (yet) have that information, so I have added this sum type here to be able
 to differentiate between clicks on different buttons.
 -}
-data Rules = AndElim1
-           | AndElim2
-           | AndIntro
-           | OrIntro
-           | NotIntro
-           | NotElim
+data Rules
+  = AndElim1
+  | AndElim2
+  | AndIntro
+  | OrIntro
+  | NotIntro
+  | NotElim

--- a/src/GUI/RulesPanel.purs
+++ b/src/GUI/RulesPanel.purs
@@ -1,7 +1,6 @@
 module GUI.RulesPanel where
 
 import Data.Maybe
-
 import Effect.Class (class MonadEffect)
 import GUI.Proof as GP
 import GUI.Rules as R
@@ -12,23 +11,26 @@ import Halogen.HTML.Properties as HP
 import Prelude (Unit, Void, discard, identity, pure, ($))
 import Type.Proxy (Proxy(..))
 
-type Slots = ( proofPanel ::                H.Slot Query Void Int
-             , proof      :: forall output. H.Slot GP.Query output Int)
+type Slots
+  = ( proofPanel :: H.Slot Query Void Int
+    , proof :: forall output. H.Slot GP.Query output Int
+    )
 
 _proofPanel = Proxy :: Proxy "proofPanel"
-_proof      = Proxy :: Proxy "proof"
 
-data Query a = Tell Output a
+_proof = Proxy :: Proxy "proof"
+
+data Query a
+  = Tell Output a
 
 proofPanel :: forall input output m. MonadEffect m => H.Component Query input output m
 proofPanel =
   H.mkComponent
     { initialState: identity
     , render
-    , eval: H.mkEval H.defaultEval { handleQuery = handleQuery}
+    , eval: H.mkEval H.defaultEval { handleQuery = handleQuery }
     }
   where
-  
   handleQuery :: forall a state action. Query a -> H.HalogenM state action Slots output m (Maybe a)
   handleQuery (Tell command a) = do
     H.tell _proof 0 (GP.Tell command)
@@ -43,21 +45,23 @@ proofPanel =
           [ HH.text "Proof" ]
       , HH.div
           [ HP.classes [ HH.ClassName "panel-block" ] ]
-          [ HH.slot_ _proof 0 GP.proof { } ]
+          [ HH.slot_ _proof 0 GP.proof {} ]
       ]
 
-type Action = R.Rules
-type Output = R.Rules
+type Action
+  = R.Rules
 
-ruleButtonPanel :: forall query m . MonadEffect m => H.Component query Int Output m
+type Output
+  = R.Rules
+
+ruleButtonPanel :: forall query m. MonadEffect m => H.Component query Int Output m
 ruleButtonPanel =
   H.mkComponent
     { initialState: identity
     , render
-    , eval: H.mkEval H.defaultEval { handleAction = handleAction}
+    , eval: H.mkEval H.defaultEval { handleAction = handleAction }
     }
   where
-
   render _ =
     HH.div
       [ HP.classes [ HH.ClassName "panel", HH.ClassName "is-primary" ] ]
@@ -71,13 +75,13 @@ ruleButtonPanel =
           ]
           [ HH.text "∧e1" ]
       , HH.button
-          [ HP.classes [ HH.ClassName "button"]
+          [ HP.classes [ HH.ClassName "button" ]
           , HP.type_ HP.ButtonSubmit
           , HE.onClick $ \_ -> R.AndElim2
           ]
           [ HH.text "∧e2" ]
       , HH.button
-          [ HP.classes [ HH.ClassName "button"]
+          [ HP.classes [ HH.ClassName "button" ]
           , HP.type_ HP.ButtonSubmit
           , HE.onClick (\_ -> R.AndIntro)
           ]
@@ -94,14 +98,13 @@ ruleButtonPanel =
           , HE.onClick (\_ -> R.NotIntro)
           ]
           [ HH.text "¬i" ]
-      , HH.button 
-          [ HP.classes [ HH.ClassName "button"]
+      , HH.button
+          [ HP.classes [ HH.ClassName "button" ]
           , HP.type_ HP.ButtonSubmit
           , HE.onClick (\_ -> R.NotElim)
           ]
-          [ HH.text "¬e"] 
+          [ HH.text "¬e" ]
       ]
 
-    
   handleAction :: forall state. Action -> H.HalogenM state Action () Output m Unit
   handleAction action = H.raise action

--- a/src/GUI/RulesPanel.purs
+++ b/src/GUI/RulesPanel.purs
@@ -1,18 +1,16 @@
 module GUI.RulesPanel where
 
-import Prelude (Unit, Void, discard, identity, pure, ($))
-import Type.Proxy (Proxy(..))
+import Data.Maybe
+
 import Effect.Class (class MonadEffect)
-
-import Halogen as H
-import Halogen.HTML as HH
-import Halogen.HTML.Properties as HP
-import Halogen.HTML.Events as HE
-
 import GUI.Proof as GP
 import GUI.Rules as R
-
-import Data.Maybe
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+import Prelude (Unit, Void, discard, identity, pure, ($))
+import Type.Proxy (Proxy(..))
 
 type Slots = ( proofPanel ::                H.Slot Query Void Int
              , proof      :: forall output. H.Slot GP.Query output Int)
@@ -84,7 +82,26 @@ ruleButtonPanel =
           , HE.onClick (\_ -> R.AndIntro)
           ]
           [ HH.text "∧i" ]
+      , HH.button
+          [ HP.classes [ HH.ClassName "button" ]
+          , HP.type_ HP.ButtonSubmit
+          , HE.onClick (\_ -> R.OrIntro)
+          ]
+          [ HH.text "∨i" ]
+      , HH.button
+          [ HP.classes [ HH.ClassName "button" ]
+          , HP.type_ HP.ButtonSubmit
+          , HE.onClick (\_ -> R.NotIntro)
+          ]
+          [ HH.text "¬i" ]
+      , HH.button 
+          [ HP.classes [ HH.ClassName "button"]
+          , HP.type_ HP.ButtonSubmit
+          , HE.onClick (\_ -> R.NotElim)
+          ]
+          [ HH.text "¬e"] 
       ]
+
     
   handleAction :: forall state. Action -> H.HalogenM state Action () Output m Unit
   handleAction action = H.raise action

--- a/src/GUI/SymbolInput.purs
+++ b/src/GUI/SymbolInput.purs
@@ -65,7 +65,7 @@ symbolInput placeholder
       = HH.input
         [ HP.value st.s
         , HP.placeholder placeholder
-        , HP.classes [ HH.ClassName "input", HH.ClassName "is-primary" ]
+        , HP.classes [ HH.ClassName "input", HH.ClassName "is-primary"]
         , HP.type_ HP.InputText
         , HP.ref ref
         , HE.onValueInput OnInput

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,4 +1,4 @@
-module Util where
+module Util (moveWithin) where
 
 import Prelude
 import Data.Maybe (Maybe)

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -1,4 +1,4 @@
-module Util (moveWithin) where
+module Util (moveWithin, findLast) where
 
 import Prelude
 import Data.Maybe (Maybe)


### PR DESCRIPTION
Jag har lagt till funktionalitet till vissa av knapparna i regelpanelen. Om man klickar t.ex på and introduction så måste användaren sedan indikera vilka två rader som regeln ska appliceras på. Just nu har jag hackat ihop detta med att man klickar på radnumret, men det är ju något vi kan prata om senare.

När man gör or introduction bör man nog bara klicka på en operand och sen manuellt få skriva in den andra. Det ska trots allt vara helt godtyckligt vad den andra operanden till or är.

Vissa regler ska appliceras på boxar, som måste ha ett visst innehåll. T.ex not introduction måste appliceras på en box där första raden i boxen är en assumption och sista raden är en bottom. Just nu sker inte detta utan den funkar som de andra knapparna (klicka på godtycklig operand), men jag tror att jag kanske vet hur man ska fixa det framöver. 