### PR TITLE
Validate proofs

### DIFF
--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -243,7 +243,7 @@ render st =
   premises =
     joinWith ", "
       $ _.formulaText
-      <$> Array.takeWhile ((_ == Premise) <<< _.rule) st.rows
+      <$> Array.filter ((_ == Premise) <<< _.rule) st.rows
 
   formulaField :: Int -> String -> String -> (String -> Action) -> HH.HTML _ _
   formulaField i placeholder text outputMap =

--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -283,11 +283,13 @@ render st =
       , formulaField (-1) "Conclusion" st.conclusion UpdateConclusion
       ]
 
+  -- | All premises used in the proof as a string.
   premises =
-    joinWith ", "
+    joinWith ", " $ Array.nub
       $ _.formulaText
       <$> Array.filter ((_ == Premise) <<< _.rule) st.rows
 
+  -- | Renders an input field that verifies the parsability of the inputted formula.
   formulaField :: Int -> String -> String -> (String -> Action) -> HH.HTML _ _
   formulaField i placeholder text outputMap =
     HH.span

--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -11,7 +11,6 @@ import Effect.Class (class MonadEffect)
 import Effect.Console (logShow)
 import Data.FoldableWithIndex (foldlWithIndex)
 import Data.List (List(Nil), (:))
-import Data.NonEmpty as NonEmpty
 import Data.NonEmpty ((:|))
 import Data.MediaType (MediaType(MediaType))
 import Data.Int as Int
@@ -131,6 +130,43 @@ handleQuery (Tell command a) = case command of
     pure Nothing
   _ -> pure Nothing
 
+-- | Tree representation of a ND proof,
+-- |
+-- | where the internal nodes are boxes and the leafs are rows.
+data ProofTree
+  = Subproof (Array ProofTree)
+  | RowNode Int ProofRow
+
+-- | Converts the GUI proof representation into an explicit tree structure.
+proofTree :: State -> Array ProofTree
+proofTree { rows } = case result of
+  root :| Nil -> root.elems
+  _ -> unsafeCrashWith "Unclosed boxes"
+  where
+  result =
+    foldlWithIndex
+      ( \i (currentBox@{ elems } :| parentBoxes) proofRow ->
+          closeBoxesIfPossible i case proofRow.rule of
+            Assumption { boxEndIdx } ->
+              { elems: [ RowNode i proofRow ], endIdx: boxEndIdx }
+                :| currentBox
+                : parentBoxes
+            _ -> (currentBox { elems = Array.snoc elems $ RowNode i proofRow }) :| parentBoxes
+      )
+      ({ elems: [], endIdx: Array.length rows } :| Nil)
+      rows
+
+  closeBoxesIfPossible i = case _ of
+    { endIdx } :| _
+      | endIdx < i -> unsafeCrashWith "Unreachable (box ends outside of parent)"
+    { elems: currentElems, endIdx } :| parent : rest
+      | endIdx == i ->
+        closeBoxesIfPossible i
+          $ parent
+              { elems = Array.snoc parent.elems $ Subproof currentElems }
+          :| rest
+    x -> x
+
 render :: forall m. MonadEffect m => State -> H.ComponentHTML Action Slots m
 render st =
   HH.div [ HP.classes [ HH.ClassName "proof" ] ]
@@ -150,37 +186,14 @@ render st =
 
   proofRows :: HH.HTML _ _
   proofRows =
-    HH.div
-      [ HP.classes [ HH.ClassName "proof-rows" ] ]
-      ( NonEmpty.head
-            $ foldlWithIndex
-                ( \i (currentBox@{ elems } :| parentBoxes) proofRow ->
-                    let
-                      closeBoxesIfPossible = case _ of
-                        { endIdx } :| _
-                          | endIdx < i -> unsafeCrashWith "Unreachable (box ends outside of parent)"
-                        { elems: currentElems, endIdx } :| parent : rest
-                          | endIdx == i ->
-                            closeBoxesIfPossible
-                              $ parent
-                                  { elems =
-                                    Array.snoc parent.elems
-                                      $ HH.div [ HP.classes [ HH.ClassName "proof-box" ] ] currentElems
-                                  }
-                              :| rest
-                        x -> x
-                    in
-                      closeBoxesIfPossible case proofRow.rule of
-                        Assumption { boxEndIdx } ->
-                          { elems: [ row i proofRow ], endIdx: boxEndIdx }
-                            :| currentBox
-                            : parentBoxes
-                        _ -> (currentBox { elems = Array.snoc elems $ row i proofRow }) :| parentBoxes
-                )
-                ({ elems: [], endIdx: Array.length st.rows } :| Nil)
-                st.rows
-        )
-        .elems
+    let
+      renderProofTree = case _ of
+        Subproof xs -> HH.div [ HP.classes [ HH.ClassName "proof-box" ] ] (renderProofTree <$> xs)
+        RowNode i r -> row i r
+    in
+      HH.div
+        [ HP.classes [ HH.ClassName "proof-rows" ] ]
+        (renderProofTree <$> proofTree st)
 
   row :: Int -> ProofRow -> HH.HTML _ _
   row i { formulaText, rule } =

--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -3,9 +3,10 @@ module GUI.Proof (Query(..), proof) where
 import Prelude
 import Type.Proxy (Proxy(..))
 import Data.Maybe (Maybe(..), fromJust, maybe)
+import Data.Either (isRight)
 import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 import Data.Array as Array
-import Data.Array ((!!))
+import Data.Array ((!!), unsafeIndex)
 import Data.FunctorWithIndex (mapWithIndex)
 import Effect.Class (class MonadEffect)
 import Effect.Console (logShow)
@@ -27,6 +28,7 @@ import Web.HTML.Event.DragEvent as DragEvent
 import Web.HTML.Event.DragEvent (DragEvent)
 import Web.HTML.Event.DataTransfer as DataTransfer
 import Util (moveWithin)
+import Parser (parseFormula)
 import GUI.SymbolInput as SI
 import GUI.SymbolInput (symbolInput)
 import GUI.Rules as R
@@ -195,46 +197,47 @@ render st =
         [ HP.classes [ HH.ClassName "proof-rows" ] ]
         (renderProofTree <$> proofTree st)
 
+  parsedRows = parseFormula <<< _.formulaText <$> st.rows
+
   row :: Int -> ProofRow -> HH.HTML _ _
   row i { formulaText, rule } =
-    HH.div
-      [ HP.classes
-          ( [ HH.ClassName "columns", HH.ClassName "is-mobile", HH.ClassName "proof-row" ]
-              <> maybe []
-                  ( \j ->
-                      if i == j then
-                        [ HH.ClassName "dragged-over" ]
-                      else
-                        []
-                  )
-                  st.draggingOver
-          )
-      , HP.draggable true
-      , HE.onKeyDown $ RowKeyEvent i
-      , HE.onDragStart $ DragStart i
-      , HE.onDragOver $ DragOver i
-      , HE.onDragEnter $ DragEnter i
-      , HE.onDragLeave $ DragLeave i
-      , HE.onDrop $ Drop i
-      , HE.onDragEnd $ DragEnd i
-      ]
-      ( [ HH.div
-            [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
-            [ HH.h4
-                [ HP.classes [ HH.ClassName "title", HH.ClassName "row-index" ] ]
-                [ HH.text (show (1 + i)) ]
-            ]
-        , HH.div
-            [ HP.classes [ HH.ClassName "column", HH.ClassName "formula-field" ] ]
-            [ HH.slot _symbolInput (2 * i) (symbolInput "Enter formula") formulaText (UpdateFormula i) ]
-        , HH.div
-            [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
-            [ HH.span
-                [ HP.classes [ HH.ClassName "rule-field" ] ]
-                [ HH.slot _symbolInput (2 * i + 1) (symbolInput "Rule") (ruleText rule) (UpdateRule i) ]
-            ]
+    let
+      isFormulaOk = isRight $ unsafePartial $ parsedRows `unsafeIndex` i
+    in
+      HH.div
+        [ HP.classes
+            ( [ HH.ClassName "columns", HH.ClassName "is-mobile", HH.ClassName "proof-row" ]
+                <> maybe []
+                    (\j -> if i == j then [ HH.ClassName "dragged-over" ] else [])
+                    st.draggingOver
+                <> if isFormulaOk then [] else [ HH.ClassName "incorrect-formula" ]
+            )
+        , HP.draggable true
+        , HE.onKeyDown $ RowKeyEvent i
+        , HE.onDragStart $ DragStart i
+        , HE.onDragOver $ DragOver i
+        , HE.onDragEnter $ DragEnter i
+        , HE.onDragLeave $ DragLeave i
+        , HE.onDrop $ Drop i
+        , HE.onDragEnd $ DragEnd i
         ]
-      )
+        ( [ HH.div
+              [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
+              [ HH.h4
+                  [ HP.classes [ HH.ClassName "title", HH.ClassName "row-index" ] ]
+                  [ HH.text (show (1 + i)) ]
+              ]
+          , HH.div
+              [ HP.classes [ HH.ClassName "column", HH.ClassName "formula-field" ] ]
+              [ HH.slot _symbolInput (2 * i) (symbolInput "Enter formula") formulaText (UpdateFormula i) ]
+          , HH.div
+              [ HP.classes [ HH.ClassName "column", HH.ClassName "is-narrow" ] ]
+              [ HH.span
+                  [ HP.classes [ HH.ClassName "rule-field" ] ]
+                  [ HH.slot _symbolInput (2 * i + 1) (symbolInput "Rule") (ruleText rule) (UpdateRule i) ]
+              ]
+          ]
+        )
 
 -- | The media type for the index of a proof row as a string.
 rowMediaType :: MediaType

--- a/src/Proof.purs
+++ b/src/Proof.purs
@@ -124,7 +124,7 @@ proofRef :: Int -> ExceptT NdError ND Formula
 proofRef i = do
   { rows, discarded } <- get
   { formula } <- except $ note RefOutOfBounds $ rows !! (i - 1)
-  when (i `Set.member` discarded) $ throwError RefDiscarded
+  when ((i - 1) `Set.member` discarded) $ throwError RefDiscarded
   except $ note BadRef formula
 
 -- | Takes a user-provided formula and ND state and tries to apply the rule.

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -8,6 +8,9 @@ import Partial.Unsafe (unsafePartial)
 import Data.Tuple (Tuple(Tuple))
 import Data.FunctorWithIndex (class FunctorWithIndex, mapWithIndex)
 import Debug (class DebugWarning, trace)
+import Data.Either (hush)
+import Control.Monad.Maybe.Trans (MaybeT(MaybeT))
+import Control.Monad.Except.Trans (ExceptT(ExceptT))
 
 enumerate :: forall i f a. FunctorWithIndex i f => f a -> f (Tuple i a)
 enumerate = mapWithIndex Tuple
@@ -35,6 +38,9 @@ findLast :: forall a. (a -> Boolean) -> Array a -> Maybe a
 findLast f xs =
   (\i -> unsafePartial $ Array.unsafeIndex xs i)
     <$> Array.findLastIndex f xs
+
+exceptToMaybeT :: forall e m a. Functor m => ExceptT e m a -> MaybeT m a
+exceptToMaybeT (ExceptT m) = MaybeT $ hush <$> m
 
 traceShowId :: forall a. DebugWarning => Show a => a -> a
 traceShowId x = trace (show x) \_ -> x

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -5,24 +5,36 @@ import Data.Maybe (Maybe)
 import Data.Array as Array
 import Data.Array (slice)
 import Partial.Unsafe (unsafePartial)
-import Data.Traversable (mapAccumL, class Traversable)
+import Data.Tuple (Tuple(Tuple))
+import Data.FunctorWithIndex (class FunctorWithIndex, mapWithIndex)
 import Debug (class DebugWarning, trace)
+
+enumerate :: forall i f a. FunctorWithIndex i f => f a -> f (Tuple i a)
+enumerate = mapWithIndex Tuple
 
 -- | Move a part of an array within itself.
 moveWithin :: forall a. Int -> Int -> Int -> Array a -> Array a
-moveWithin target start end
-  = if target == start then identity
-    else if target < start then go target start end
-         else go start end target
-  where go i j k xs = Array.concat [ Array.take i xs
-                                   , slice j k xs
-                                   , slice i j xs
-                                   , Array.drop k xs
-                                   ]
+moveWithin target start end =
+  if target == start then
+    identity
+  else
+    if target < start then
+      go target start end
+    else
+      go start end target
+  where
+  go i j k xs =
+    Array.concat
+      [ Array.take i xs
+      , slice j k xs
+      , slice i j xs
+      , Array.drop k xs
+      ]
 
 findLast :: forall a. (a -> Boolean) -> Array a -> Maybe a
-findLast f xs = (\i -> unsafePartial $ Array.unsafeIndex xs i)
-                <$> Array.findLastIndex f xs
+findLast f xs =
+  (\i -> unsafePartial $ Array.unsafeIndex xs i)
+    <$> Array.findLastIndex f xs
 
 traceShowId :: forall a. DebugWarning => Show a => a -> a
 traceShowId x = trace (show x) \_ -> x

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -133,10 +133,14 @@ $input-shadow: $primary;
 	}
 }
 
-.proof-row .invalid input {
+.rule-arg-input {
+	width: 4rem;
+}
+
+.proof-row .invalid input, .formula-field.invalid input {
 	border-color: red;
 }
 
-.rule-arg-input {
-	width: 4rem;
+.proof.complete .proof-row:last-child {
+	border: solid green;
 }

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -132,3 +132,7 @@ $input-shadow: $primary;
 		opacity: 1;
 	}
 }
+
+.proof-row.incorrect-formula > .formula-field > input {
+	border-color: red;
+}

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -136,3 +136,11 @@ $input-shadow: $primary;
 .formula-field.incorrect-formula > input {
 	border-color: red;
 }
+
+.rule-arg-input {
+	width: 4rem;
+}
+
+.rule-arg-input.invalid-rule-arg {
+	border-color: red;
+}

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -141,6 +141,6 @@ $input-shadow: $primary;
 	border-color: red;
 }
 
-.proof.complete .proof-row:last-child {
+.proof.complete .proof-rows > .proof-row:last-child {
 	border: solid green;
 }

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -133,14 +133,10 @@ $input-shadow: $primary;
 	}
 }
 
-.formula-field.incorrect-formula > input {
+.proof-row .invalid input {
 	border-color: red;
 }
 
 .rule-arg-input {
 	width: 4rem;
-}
-
-.rule-arg-input.invalid-rule-arg {
-	border-color: red;
 }

--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -133,6 +133,6 @@ $input-shadow: $primary;
 	}
 }
 
-.proof-row.incorrect-formula > .formula-field > input {
+.formula-field.incorrect-formula > input {
 	border-color: red;
 }


### PR DESCRIPTION
Gör så att GUI:t anropar Proof modulen för att validera bevisrader. Saker som kan förbättras:

- Lägga till resten av bevisreglerna. Bara ett subset är implementerade.
- Visa felmeddelanden tydligare. Nu visas de bara som mouseover text på rule-fältet.
- Nu blir rule argumentfälten bara felmarkerade om användaren skriver in något annat än nummer. Om det är ett ogiltligt argument blir bara själva rulefältet felmarkerat.