### PR TITLE
Fix indexing error in scope check.

### DIFF
--- a/src/Proof.purs
+++ b/src/Proof.purs
@@ -217,7 +217,7 @@ applyRule rule formula = do
     OrElim i box1 box2 -> do
       a <- proofRef i
       (Tuple b1 b2) <- boxRef box1
-      (Tuple c1 c2) <- boxRef box1
+      (Tuple c1 c2) <- boxRef box2
       case a of
         Or f1 f2 -> if f1 == b1 && f2 == c1 && b2 == c2 then pure b2 else throwError BadRule
         _ -> throwError BadRule

--- a/src/Proof.purs
+++ b/src/Proof.purs
@@ -168,7 +168,7 @@ proofRef :: Int -> ExceptT NdError ND Formula
 proofRef i = do
   { rows, scopes } <- get
   { formula, error } <- except $ note RefOutOfBounds $ rows Array.!! (i - 1)
-  when (not (lineInScope (i - 1) scopes)) $ throwError RefDiscarded
+  when (not (lineInScope i scopes)) $ throwError RefDiscarded
   when (error == Just BadFormula) $ throwError BadRef -- User needs to have input the formula
   except $ note BadRef formula
 


### PR DESCRIPTION
Scope checking in Proof.proofRef calls Proof.lineInScope with wrong index.