### PR TITLE
Fix issues with premises field

### DIFF
--- a/src/Parser.purs
+++ b/src/Parser.purs
@@ -144,6 +144,6 @@ parsePremises s =
   let
     result = runParser s $ token.whiteSpace *> sepBy1 premise (char ',' <* token.whiteSpace)
 
-    premise = parsedString $ void (try formula) <|> void (many anyChar)
+    premise = parsedString $ void (try $ formula <* lookAhead (char ',')) <|> void (many anyChar)
   in
     fromRight' (\_ -> unsafeCrashWith "unreachable (parser always succeeds)") result


### PR DESCRIPTION
1. It was possible to (I) Add a premise; (II) Remove other rows
   and (III) Remove the premise, to end up with zero proof rows.

2. Premises would be unconditionally split on "," even if commas were
   used to separate arguments to e.g. a predicate.