### PR TITLE
Allow 1st row of box as box-range rule arg

### DIFF
--- a/src/sass/mystyles.scss
+++ b/src/sass/mystyles.scss
@@ -77,11 +77,11 @@ $modal-card-title-color: findColorInvert($modal-card-head-background-color);
 .proof-header {
 	display: flex;
 	justify-content: space-around;
-	
+
 	margin: 1rem auto;
 
 	white-space: nowrap;
-	vertical-align:top;
+	vertical-align: top;
 }
 
 .proof-rows {
@@ -185,6 +185,16 @@ $modal-card-title-color: findColorInvert($modal-card-head-background-color);
 
 .arg-field {
 	width: 4rem;
+
+	&.hint {
+		position: absolute;
+		border-color: transparent;
+		color: #999;
+	}
+
+	&:not(.hint) {
+		background-color: transparent;
+	}
 }
 
 [role="toolbar"] {


### PR DESCRIPTION
Tillåter användaren att endast skriva in första raden av en box som argument till regler som t.ex. PBC, då detta kan göras otvetydigt. I grått visas vilken box range som faktiskt syftas på.

![image](https://user-images.githubusercontent.com/3679678/117869816-8ff7f880-b29b-11eb-8d11-028c9e372b98.png)
