### PR TITLE
Only contextually parse input as VC

### DIFF
--- a/src/GUI/Config/Text.purs
+++ b/src/GUI/Config/Text.purs
@@ -4,7 +4,7 @@ editorName :: String
 editorName = "Logan"
 
 editorSlogan :: String
-editorSlogan = "A fitch-style proof editor for first order logic"
+editorSlogan = "A fitch-style proof editor for first-order logic"
 
 panelNotImplemented :: String
 panelNotImplemented = "This panel has not been implemented yet."

--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -22,7 +22,7 @@ import Data.String as String
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(Tuple), snd)
 import Effect.Class (class MonadEffect)
-import FormulaOrVar (parseFFC)
+import FormulaOrVar (FFC(FC, VC), parseFFC)
 import GUI.Hint as Hint
 import GUI.Rules (RuleType(..))
 import GUI.Rules as R
@@ -33,7 +33,7 @@ import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
 import Halogen.HTML.Properties.ARIA as HPARIA
-import Parser (parsePremises)
+import Parser (parseFormula, parseVar, parsePremises)
 import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 import Proof (NdError(..))
 import Proof as P
@@ -496,7 +496,13 @@ render st =
         RowNode _ r ->
           pure
             $ P.addProof
-                { formula: hush $ parseFFC r.formulaText
+                { formula:
+                    hush
+                      $ ( case parseRuleText (ruleText r.rule) of
+                            Just RtFresh -> map VC <$> parseVar
+                            _ -> map FC <$> parseFormula
+                        )
+                          r.formulaText
                 , rule: parseRule r
                 }
 


### PR DESCRIPTION
Otherwise lowercase atomic propositions would get parsed as variables. Since only Fresh rule applications output variables, we can treat it as a special case.

This is a hack.