### PR TITLE
Export as LaTeX

### DIFF
--- a/src/Formula.purs
+++ b/src/Formula.purs
@@ -33,6 +33,7 @@ import Data.Set (Set)
 import Data.Set as Set
 import Data.String.Common (joinWith)
 import Data.Tuple (Tuple(Tuple))
+import Latex (class Latex, toLatex)
 
 -- | A variable symbol.
 newtype Variable
@@ -46,6 +47,9 @@ derive newtype instance semigroupVariable :: Semigroup Variable
 
 instance showVariable :: Show Variable where
   show (Variable s) = s
+
+instance latexVariable :: Latex Variable where
+  toLatex (Variable s) = s
 
 -- | A term which denotes some object.
 -- |
@@ -64,6 +68,10 @@ instance showTerm :: Show Term where
   show (Var v) = show v
   show (App p args) = p <> "(" <> (joinWith ", " (show <$> args)) <> ")"
 
+instance latexTerm :: Latex Term where
+  toLatex (Var v) = show v
+  toLatex (App p args) = p <> "(" <> (joinWith ", " (toLatex <$> args)) <> ")"
+
 -- | A formula in first-order logic.
 data Formula
   = Predicate String (Array Term)
@@ -80,22 +88,39 @@ derive instance ordFormula :: Ord Formula
 
 -- | Shows formulas using least amount of parentheses wrt. precedence.
 instance showFormula :: Show Formula where
-  show = showPrec 1
+  show = showPrec symbol 1
     where
-    parens s = "(" <> s <> ")"
+      symbol s = s
 
-    optParens b s = if b then parens s else s
+instance latexFormula :: Latex Formula where
+  toLatex = showPrec symbol 1
+    where
+      symbol "⊥" = "\\bot"
+      symbol "¬" = "\\lnot "
+      symbol "∧" = "\\land"
+      symbol "∨" = "\\lor"
+      symbol "→" = "\\to"
+      symbol "∀" = "\\forall "
+      symbol "∃" = "\\exists "
+      symbol s = s
 
-    showPrec n = case _ of
-      Predicate p [] -> p
-      Predicate "=" [ x, y ] -> show x <> " = " <> show y
-      Predicate p args -> p <> parens (joinWith ", " (show <$> args))
-      Not f -> "¬" <> showPrec 4 f
-      Forall x f -> "∀" <> show x <> " " <> showPrec 4 f
-      Exists x f -> "∃" <> show x <> " " <> showPrec 4 f
-      And a b -> optParens (n > 3) $ showPrec 3 a <> " ∧ " <> showPrec 4 b
-      Or a b -> optParens (n > 2) $ showPrec 2 a <> " ∨ " <> showPrec 3 b
-      Implies a b -> optParens (n > 1) $ showPrec 2 a <> " → " <> showPrec 1 b
+parens :: String -> String
+parens s = "(" <> s <> ")"
+
+optParens :: Boolean -> String -> String
+optParens b s = if b then parens s else s
+
+showPrec :: (String -> String) -> Int -> Formula -> String
+showPrec symbol n = case _ of
+  Predicate p [] -> symbol p
+  Predicate "=" [ x, y ] -> show x <> " " <> symbol "=" <> " " <> show y
+  Predicate p args -> symbol p <> parens (joinWith ", " (show <$> args))
+  Not f -> symbol "¬" <> showPrec symbol 4 f
+  Forall x f -> symbol "∀" <> show x <> " " <> showPrec symbol 4 f
+  Exists x f -> symbol "∃" <> show x <> " " <> showPrec symbol 4 f
+  And a b -> optParens (n > 3) $ showPrec symbol 3 a <> " " <> symbol "∧" <> " " <> showPrec symbol 4 b
+  Or a b -> optParens (n > 2) $ showPrec symbol 2 a <> " " <> symbol "∨" <> " " <> showPrec symbol 3 b
+  Implies a b -> optParens (n > 1) $ showPrec symbol 2 a <> " " <> symbol "→" <> " " <> showPrec symbol 1 b
 
 -- | Dedicated symbol for a proposition that is assigned a false truth value.
 bottomProp :: Formula
@@ -117,6 +142,15 @@ instance showSubstitution :: Show Substitution where
       showElem (Tuple t v) = show t <> "/" <> show v
     in
       "{" <> joinWith ", " (showElem <$> elems) <> "}"
+
+instance latexSubstitution :: Latex Substitution where
+  toLatex (Substitution ss) =
+    let
+      elems = Map.toUnfoldableUnordered ss :: Array _
+
+      showElem (Tuple t v) = toLatex t <> "/" <> toLatex v
+    in
+      "\\{" <> joinWith ", " (showElem <$> elems) <> "\\}"
 
 instance semigroupSubstitution :: Semigroup Substitution where
   -- | The composition of the two substitutions.

--- a/src/Formula.purs
+++ b/src/Formula.purs
@@ -95,20 +95,14 @@ instance showFormula :: Show Formula where
 instance latexFormula :: Latex Formula where
   toLatex = showPrec symbol 1
     where
-      symbol "⊥" = "\\bot"
+      symbol "⊥" = "\\bot "
       symbol "¬" = "\\lnot "
-      symbol "∧" = "\\land"
-      symbol "∨" = "\\lor"
-      symbol "→" = "\\to"
+      symbol "∧" = "\\land "
+      symbol "∨" = "\\lor "
+      symbol "→" = "\\to "
       symbol "∀" = "\\forall "
       symbol "∃" = "\\exists "
       symbol s = s
-
-parens :: String -> String
-parens s = "(" <> s <> ")"
-
-optParens :: Boolean -> String -> String
-optParens b s = if b then parens s else s
 
 showPrec :: (String -> String) -> Int -> Formula -> String
 showPrec symbol n = case _ of
@@ -121,6 +115,9 @@ showPrec symbol n = case _ of
   And a b -> optParens (n > 3) $ showPrec symbol 3 a <> " " <> symbol "∧" <> " " <> showPrec symbol 4 b
   Or a b -> optParens (n > 2) $ showPrec symbol 2 a <> " " <> symbol "∨" <> " " <> showPrec symbol 3 b
   Implies a b -> optParens (n > 1) $ showPrec symbol 2 a <> " " <> symbol "→" <> " " <> showPrec symbol 1 b
+  where
+    parens s = "(" <> s <> ")"
+    optParens b s = if b then parens s else s
 
 -- | Dedicated symbol for a proposition that is assigned a false truth value.
 bottomProp :: Formula

--- a/src/Formula.purs
+++ b/src/Formula.purs
@@ -95,13 +95,13 @@ instance showFormula :: Show Formula where
 instance latexFormula :: Latex Formula where
   toLatex = showPrec symbol 1
     where
-      symbol "⊥" = "\\bot "
-      symbol "¬" = "\\lnot "
-      symbol "∧" = "\\land "
-      symbol "∨" = "\\lor "
-      symbol "→" = "\\to "
-      symbol "∀" = "\\forall "
-      symbol "∃" = "\\exists "
+      symbol "⊥" = "\\bot{}"
+      symbol "¬" = "\\lnot{}"
+      symbol "∧" = "\\land{}"
+      symbol "∨" = "\\lor{}"
+      symbol "→" = "\\to{}"
+      symbol "∀" = "\\forall{}"
+      symbol "∃" = "\\exists{}"
       symbol s = s
 
 showPrec :: (String -> String) -> Int -> Formula -> String

--- a/src/FormulaOrVar.purs
+++ b/src/FormulaOrVar.purs
@@ -8,6 +8,7 @@ import Control.Alternative ((<|>))
 import Data.Either (Either)
 import Text.Parsing.Parser (ParseError)
 import Formula (Variable, Formula)
+import Latex (class Latex, toLatex)
 import Parser (parseFormula, parseVar)
 
 data FFC
@@ -19,6 +20,10 @@ derive instance eqFFC :: Eq FFC
 instance showFFC :: Show FFC where
   show (FC f) = "FC: " <> show f
   show (VC v) = "VC: " <> show v
+
+instance latexFFC :: Latex FFC where
+  toLatex (FC f) = toLatex f
+  toLatex (VC v) = toLatex v
 
 parseFFC :: String -> Either ParseError FFC
 parseFFC s = (VC <$> parseVar s) <|> (FC <$> parseFormula s)

--- a/src/GUI/GUI.purs
+++ b/src/GUI/GUI.purs
@@ -61,7 +61,7 @@ siteBody =
                 [ HP.classes [ HH.ClassName "columns" ] ]
                 [ HH.div
                     [ HP.classes [ HH.ClassName "column", HH.ClassName "is-three-quarters" ] ]
-                    [ HH.slot_ _proof unit GP.proof unit ]
+                    [ HH.slot _proof unit GP.proof 0 ActivateModal ]
                 , HH.div
                     [ HP.classes [ HH.ClassName "column" ] ]
                     [ HH.slot _settingsPanel unit SP.settingsPanel 0 ActivateModal
@@ -81,12 +81,16 @@ siteBody =
   modal m = case m of
     SP.ManualModal -> manualModal
     SP.ShortcutModal -> shortcutModal
+    (SP.ExportLatexModal latex) -> exportLatexModal latex
 
   manualModal :: HH.HTML _ _
   manualModal = mkModal "How to use the editor." manualModalBody
 
   shortcutModal :: HH.HTML _ _
   shortcutModal = mkModal "Syntax shortcuts." shortcutModalBody
+
+  exportLatexModal :: String -> HH.HTML _ _
+  exportLatexModal latex = mkModal "Export as LaTeX." $ exportLatexModalBody latex
 
   mkModal :: String -> (HH.HTML _ _) -> HH.HTML _ _
   mkModal title modalBody =
@@ -402,4 +406,15 @@ shortcutModalBody =
                 ]
             ]
         ]
+    ]
+
+exportLatexModalBody :: forall w. String -> HH.HTML w Action
+exportLatexModalBody latex =
+  HH.div [ HP.classes [ HH.ClassName "content" ] ]
+    [ HH.p_
+        [ HH.text "Here you can find the source for including your proof in a LaTeX document. To render properly you will need to use the "
+        , HH.code_ [ HH.text "logicproof" ]
+        , HH.text " package."
+        ]
+    , HH.pre_ [ HH.code_ [ HH.text latex ] ]
     ]

--- a/src/GUI/GUI.purs
+++ b/src/GUI/GUI.purs
@@ -61,7 +61,7 @@ siteBody =
                 [ HP.classes [ HH.ClassName "columns" ] ]
                 [ HH.div
                     [ HP.classes [ HH.ClassName "column", HH.ClassName "is-three-quarters" ] ]
-                    [ HH.slot _proof unit GP.proof 0 ActivateModal ]
+                    [ HH.slot _proof unit GP.proof unit (case _ of GP.LatexOutput s -> ActivateModal $ SP.ExportLatexModal s) ]
                 , HH.div
                     [ HP.classes [ HH.ClassName "column" ] ]
                     [ HH.slot _settingsPanel unit SP.settingsPanel 0 ActivateModal
@@ -81,7 +81,7 @@ siteBody =
   modal m = case m of
     SP.ManualModal -> manualModal
     SP.ShortcutModal -> shortcutModal
-    (SP.ExportLatexModal latex) -> exportLatexModal latex
+    SP.ExportLatexModal latex -> exportLatexModal latex
 
   manualModal :: HH.HTML _ _
   manualModal = mkModal "How to use the editor." manualModalBody

--- a/src/GUI/Proof.purs
+++ b/src/GUI/Proof.purs
@@ -4,7 +4,7 @@
 -- | modify, i.e. has a single contiguous array of all rows. When
 -- | rendering or validating we map this to a tree with subproof
 -- | nodes.
-module GUI.Proof (Slot, Output, proof) where
+module GUI.Proof (Slot, Output(..), proof) where
 
 import Prelude
 
@@ -29,7 +29,6 @@ import GUI.Hint as Hint
 import GUI.PrintProof as PrintProof 
 import GUI.Rules (RuleType(..))
 import GUI.Rules as R
-import GUI.SettingsPanel as SP
 import GUI.SymbolInput (symbolInput)
 import GUI.SymbolInput as SI
 import Halogen as H
@@ -305,8 +304,8 @@ _symbolInput = Proxy :: Proxy "symbolInput"
 type Slots
   = ( symbolInput :: SI.Slot Int )
 
-type Output
-  = SP.Modal
+data Output
+  = LatexOutput String
 
 proof :: forall query input m. MonadEffect m => H.Component query input Output m
 proof =
@@ -787,7 +786,7 @@ handleAction = case _ of
     H.liftEffect $ PrintProof.printProof
   ExportLatex -> do
     st <- H.get
-    H.raise $ SP.ExportLatexModal $ stateToLatex st
+    H.raise $ LatexOutput $ stateToLatex st
 
 
   AddBelow -> do

--- a/src/GUI/SettingsPanel.purs
+++ b/src/GUI/SettingsPanel.purs
@@ -15,6 +15,7 @@ type Output
 data Modal
   = ManualModal
   | ShortcutModal
+  | ExportLatexModal String
 
 settingsPanel :: forall query input m. H.Component query input Output m
 settingsPanel =

--- a/src/Latex.purs
+++ b/src/Latex.purs
@@ -1,0 +1,5 @@
+module Latex (class Latex, toLatex) where
+
+-- | A class for types that can be converted to LaTeX.
+class Latex a where
+  toLatex :: a -> String

--- a/src/Proof.purs
+++ b/src/Proof.purs
@@ -32,6 +32,7 @@ import Data.Maybe (Maybe(..), maybe, fromJust, isJust, isNothing)
 import Data.Set (Set)
 import Data.Set as Set
 import Data.Tuple (Tuple(..))
+import Latex (class Latex)
 import Formula (Formula(..), Variable, Term(..), freeVarsIn, almostEqual, bottomProp, equivalent, hasSingleSubOf)
 import FormulaOrVar (FFC(FC, VC))
 import Partial.Unsafe (unsafeCrashWith, unsafePartial)
@@ -93,6 +94,42 @@ instance showRule :: Show Rule where
   show (ExistsIntro _) = "∃i"
   show (EqElim _ _) = "=e"
   show EqIntro = "=i"
+
+instance latexRule :: Latex Rule where
+  toLatex Premise = "Premise"
+  toLatex Assumption = "Assumption"
+  toLatex (AndElim1 a) = "$\\land_{e_1}$ (" <> maybeIntToLatex a <> ")"
+  toLatex (AndElim2 a) = "$\\land_{e_2}$ (" <> maybeIntToLatex a <> ")"
+  toLatex (AndIntro a b) = "$\\land_i$ (" <> maybeIntToLatex a <> ", " <> maybeIntToLatex b <> ")"
+  toLatex (OrElim a b c) = "$\\lor_e$ (" <> maybeIntToLatex a <> ", " <> maybeBoxToLatex b <> ", " <> maybeBoxToLatex c <> ")"
+  toLatex (OrIntro1 a) = "$\\lor_{i_1}$ (" <> maybeIntToLatex a <> ")"
+  toLatex (OrIntro2 a) = "$\\lor_{i_2}$ (" <> maybeIntToLatex a <> ")"
+  toLatex (ImplElim a b) = "$\\to_e$ (" <> maybeIntToLatex a <> ", " <> maybeIntToLatex b <> ")"
+  toLatex (ImplIntro a) = "$\\to_i$ (" <> maybeBoxToLatex a <> ")"
+  toLatex (NegElim a b) = "$\\neg_e$ (" <> maybeIntToLatex a <> ", " <> maybeIntToLatex b <> ")"
+  toLatex (NegIntro a) = "$\\neg_i$ (" <> maybeBoxToLatex a <> ")"
+  toLatex (BottomElim a) = "$\\bot_e$ (" <> maybeIntToLatex a <> ")"
+  toLatex (DoubleNegElim a) = "$\\neg\\neg_e$ (" <> maybeIntToLatex a <> ")"
+  toLatex (ModusTollens a b) = "MT (" <> maybeIntToLatex a <> ", " <> maybeIntToLatex b <> ")"
+  toLatex (DoubleNegIntro a) = "$\\neg\\neg_i$ (" <> maybeIntToLatex a <> ")"
+  toLatex (PBC a) = "PBC (" <> maybeBoxToLatex a <> ")"
+  toLatex LEM = "LEM"
+  toLatex (Copy a) = "Copy (" <> maybeIntToLatex a <> ")"
+  toLatex Fresh = "Fresh"
+  toLatex (ForallElim a) = "$\\forall_e$ (" <> maybeIntToLatex a <> ")"
+  toLatex (ForallIntro a) = "$\\forall_i$ (" <> maybeBoxToLatex a <> ")"
+  toLatex (ExistsElim a b) = "$\\exists_e$ (" <> maybeIntToLatex a <> ", " <> maybeBoxToLatex b <> ")"
+  toLatex (ExistsIntro a) = "$\\exists_i$ (" <> maybeIntToLatex a <> ")"
+  toLatex (EqElim a b) = "$=_e$ (" <> maybeIntToLatex a <> ", " <> maybeIntToLatex b <> ")"
+  toLatex EqIntro = "$=_i$"
+
+maybeIntToLatex :: Maybe Int -> String
+maybeIntToLatex Nothing = ""
+maybeIntToLatex (Just a) = show a
+
+maybeBoxToLatex :: Maybe Box -> String
+maybeBoxToLatex Nothing = ""
+maybeBoxToLatex (Just (Tuple f t)) = show f <> "--" <> show t
 
 data NdError
   = BadRef

--- a/test/Formula.purs
+++ b/test/Formula.purs
@@ -33,6 +33,7 @@ import Formula
   , unify
   , formulaUnifier
   )
+import Latex (toLatex)
 import Parser (parseFormula, parseVar)
 
 -- | Generator for a single uppercase letter string.
@@ -119,6 +120,7 @@ spec =
     disagreementSetTests
     unificationTests
     showTests
+    toLatexTests
   where
   substitutionTests =
     describe "substitutions" do
@@ -260,6 +262,25 @@ spec =
       it "should survive show/parseFormula roundtrip"
         $ quickCheck \(TFormula formula) ->
             parseFormula (show formula) `assertEquals` Right formula
+
+  toLatexTests =
+    describe "toLatex" do
+      it "should handle precedence" do
+        toLatex (Or (Predicate "A" []) (Not $ Predicate "A" []))
+          `shouldEqual`
+            "A \\lor \\lnot A"
+        toLatex (Exists (Variable "x") (Implies (Predicate "P" [ Var $ Variable "x" ]) (Predicate "Q" [ Var $ Variable "x" ])))
+          `shouldEqual`
+            "\\exists x (P(x) \\to Q(x))"
+      it "should handle associativity" do
+        toLatex (And (And (Predicate "A" []) (Predicate "B" [])) (Predicate "C" []))
+          `shouldEqual`
+            "A \\land B \\land C"
+        toLatex (And (Predicate "A" []) (And (Predicate "B" []) (Predicate "C" [])))
+          `shouldEqual`
+            "A \\land (B \\land C)"
+      it "should format equality nicely" do
+        toLatex (Predicate "=" [ Var x, Var y ]) `shouldEqual` "x = y"
 
   x = Variable "x"
 

--- a/test/Formula.purs
+++ b/test/Formula.purs
@@ -268,17 +268,17 @@ spec =
       it "should handle precedence" do
         toLatex (Or (Predicate "A" []) (Not $ Predicate "A" []))
           `shouldEqual`
-            "A \\lor \\lnot A"
+            "A \\lor{} \\lnot{}A"
         toLatex (Exists (Variable "x") (Implies (Predicate "P" [ Var $ Variable "x" ]) (Predicate "Q" [ Var $ Variable "x" ])))
           `shouldEqual`
-            "\\exists x (P(x) \\to Q(x))"
+            "\\exists{}x (P(x) \\to{} Q(x))"
       it "should handle associativity" do
         toLatex (And (And (Predicate "A" []) (Predicate "B" [])) (Predicate "C" []))
           `shouldEqual`
-            "A \\land B \\land C"
+            "A \\land{} B \\land{} C"
         toLatex (And (Predicate "A" []) (And (Predicate "B" []) (Predicate "C" [])))
           `shouldEqual`
-            "A \\land (B \\land C)"
+            "A \\land{} (B \\land{} C)"
       it "should format equality nicely" do
         toLatex (Predicate "=" [ Var x, Var y ]) `shouldEqual` "x = y"
 


### PR DESCRIPTION
This PR adds a button for exporting a proof as LaTeX source. When clicked a modal is opened containing a brief description on how to use it, and the actual LaTeX source.

<details>
<summary>Images displaying UI and LaTeX render (Click to open)</summary>

The modal looks like this. You can also see the button in the background next to the "Save" button.  
![UI](https://user-images.githubusercontent.com/15267120/132988834-d863cccb-f59a-4011-a761-e355a68dbcf0.png)  
When rendered in LaTeX the result looks like this.  
![Rendered](https://user-images.githubusercontent.com/15267120/132988835-2b115e5e-92e4-4508-8ed8-214c46b842c1.png)

</details>

I've added a class `Latex` with a `toLatex` function, and implemented it for `Rule`, `FFC`, `Formula`, and `ProofTree` among others. For the Formula implementation I factored out substantial portions of its `Show` implementation to keep from repeating that code. I've also added specific `-ToLatex` functions for `Array ProofTree` and `GUI.Proof.State`.

For the UI I've added a new modal `exportLatexModal` (with render logic in `GUI`) that can be opened from the `GUI.Proof.proof` component. For this to work I changed the "output" of it to be the same as the `GUI.SettingsPanel.settingsPanel` (namely `GUI.SettingsPanel.Modal`).

If you have any questions, or things you want me to change, please ask.

Closes #80.